### PR TITLE
Setter kommunenr-parameter til tpsws adressesøk

### DIFF
--- a/server/src/api/endpoints/search/postnrSearchHandler.ts
+++ b/server/src/api/endpoints/search/postnrSearchHandler.ts
@@ -74,6 +74,7 @@ export const postnrSearchHandler = async (req: Request, res: Response) => {
 
     const adresseSokResponse = await fetchTpsAdresseSok(
         postnr,
+        poststedData.kommunenr,
         gatenavn,
         husnr
     );

--- a/server/src/data/poststeder.ts
+++ b/server/src/data/poststeder.ts
@@ -32,7 +32,10 @@ export const getPoststed = async (postnr: string): Promise<Poststed | null> => {
         return localData;
     }
 
-    const adresseSokResponse = await fetchTpsAdresseSok(postnr);
+    const adresseSokResponse = await fetchTpsAdresseSok(
+        postnr,
+        localData.kommunenr
+    );
 
     if (!adresseSokResponse.error) {
         const officeInfo = officeInfoFromAdresseSokResponse(adresseSokResponse);

--- a/server/src/external/postnr.ts
+++ b/server/src/external/postnr.ts
@@ -58,6 +58,7 @@ export const officeInfoFromAdresseSokResponse = (
 
 export const fetchTpsAdresseSok = async (
     postnr: string,
+    kommunenr: string,
     gatenavn?: string,
     husnr?: string
 ): Promise<AdresseSokResponse | FetchErrorResponse> => {
@@ -71,6 +72,7 @@ export const fetchTpsAdresseSok = async (
         serverUrls.postnrApi,
         {
             postnr,
+            kommunenr,
             ...(gatenavn
                 ? { adresse: gatenavn, ...(husnr && { husnr }) }
                 : { husnr: '0001' }),


### PR DESCRIPTION
adressesoek-api'et i tpsws ser ikke lengre ut til å gi noen treff på rene postnr-søk. Vi bruker dette for å finne kontorer i byer med flere et enn ett kontor.

Sender nå også kommunenr som parameter for dette søket, det ser da ut til å fungere igjen.