### PR TITLE
Oppdatert avhengigheter 200624

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,31 +11,31 @@
                 "server"
             ],
             "dependencies": {
-                "@navikt/ds-css": "6.10.0",
+                "@navikt/ds-css": "6.11.0",
                 "@navikt/ds-icons": "3.4.3",
-                "@navikt/ds-react": "6.10.0",
+                "@navikt/ds-react": "6.11.0",
                 "@navikt/nav-dekoratoren-moduler": "2.1.6",
                 "@preact/compat": "17.1.2",
                 "lodash.debounce": "4.0.8",
-                "preact-render-to-string": "6.5.4"
+                "preact-render-to-string": "6.5.5"
             },
             "devDependencies": {
-                "@babel/preset-react": "7.24.6",
+                "@babel/preset-react": "7.24.7",
                 "@octokit/core": "6.1.2",
                 "@originjs/vite-plugin-commonjs": "1.0.3",
                 "@preact/preset-vite": "2.8.2",
-                "@testing-library/jest-dom": "6.4.5",
+                "@testing-library/jest-dom": "6.4.6",
                 "@testing-library/react": "16.0.0",
                 "@types/jest": "29.5.12",
                 "@types/lodash.debounce": "4.0.9",
                 "@types/react": "18.3.3",
                 "@types/react-dom": "18.3.0",
                 "@types/react-test-renderer": "18.3.0",
-                "@typescript-eslint/eslint-plugin": "7.12.0",
-                "@typescript-eslint/parser": "7.12.0",
+                "@typescript-eslint/eslint-plugin": "7.13.1",
+                "@typescript-eslint/parser": "7.13.1",
                 "eslint": "8.57.0",
-                "eslint-plugin-react": "7.34.2",
-                "fetch-mock": "9.11.0",
+                "eslint-plugin-react": "7.34.3",
+                "fetch-mock": "10.0.7",
                 "husky": "9.0.11",
                 "identity-obj-proxy": "3.0.0",
                 "jest": "29.7.0",
@@ -43,11 +43,11 @@
                 "jest-fetch-mock": "3.0.3",
                 "node-fetch": "2.6.7",
                 "npm-run-all": "4.1.5",
-                "prettier": "3.3.0",
+                "prettier": "3.3.2",
                 "react-test-renderer": "18.3.1",
-                "ts-jest": "29.1.4",
+                "ts-jest": "29.1.5",
                 "typescript": "5.4.5",
-                "vite": "5.2.12"
+                "vite": "5.3.1"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -60,9 +60,9 @@
             }
         },
         "node_modules/@adobe/css-tools": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
-            "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.0.tgz",
+            "integrity": "sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==",
             "dev": true
         },
         "node_modules/@ampproject/remapping": {
@@ -78,13 +78,13 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.22.13",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.22.13",
-                "chalk": "^2.4.2"
+                "@babel/highlight": "^7.24.7",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -130,14 +130,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
-            "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+            "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.23.3",
-                "@jridgewell/gen-mapping": "^0.3.2",
-                "@jridgewell/trace-mapping": "^0.3.17",
+                "@babel/types": "^7.24.7",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
             },
             "engines": {
@@ -145,25 +145,26 @@
             }
         },
         "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.2",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.6.tgz",
-            "integrity": "sha512-DitEzDfOMnd13kZnDqns1ccmftwJTS9DMkyn9pYTxulS7bZxUxpMly3Nf23QQ6NwA4UB8lAqjbqWtyvElEMAkg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -186,46 +187,50 @@
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+            "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
             "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.24.7"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+            "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.22.15",
-                "@babel/types": "^7.23.0"
+                "@babel/template": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+            "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.6.tgz",
-            "integrity": "sha512-a26dmxFJBF62rRO9mmpgrfTLsAuyHk4e1hKTUkD/fcMfynt8gvEKwQPQDVxWhca8dHoDck+55DFt42zV0QMw5g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+            "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -251,9 +256,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.6.tgz",
-            "integrity": "sha512-MZG/JcWfxybKwsA9N9PmtF2lOSFSEMVCpIRrbxccZFLJPrJciJdG/UhSh5W96GEteJI2ARqm5UAHxISwRDLSNg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+            "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -272,39 +277,39 @@
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+            "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.6.tgz",
-            "integrity": "sha512-WdJjwMEkmBicq5T9fm/cHND3+UlFa2Yj8ALLgmoSQAJZysYbBjw+azChSGPN4DSPLXOcooGRvDwZWMcF/mLO2Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+            "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz",
-            "integrity": "sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.6.tgz",
-            "integrity": "sha512-Jktc8KkF3zIkePb48QO+IapbXlSapOW9S+ogZZkcO6bABgYAxtZcjZ/O005111YLf+j4M84uEgwYoidDkXbCkQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
+            "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -325,23 +330,24 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-            "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.20",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
-            "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+            "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -411,12 +417,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.6.tgz",
-            "integrity": "sha512-lWfvAIFNWMlCsU0DRUun2GpFwZdGTukLaHJqRh1JRb80NdAP5Sb1HDHB5X9P9OtgZHQl089UzQkpYlBq2VTPRw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+            "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -528,12 +534,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-display-name": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.6.tgz",
-            "integrity": "sha512-/3iiEEHDsJuj9QU09gbyWGSUxDboFcD7Nj6dnHIlboWSodxXAoaY/zlNMHeYAC0WsERMqgO9a7UaM77CsYgWcg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.7.tgz",
+            "integrity": "sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -543,16 +549,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.6.tgz",
-            "integrity": "sha512-pCtPHhpRZHfwdA5G1Gpk5mIzMA99hv0R8S/Ket50Rw+S+8hkt3wBWqdqHaPw0CuUYxdshUgsPiLQ5fAs4ASMhw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.7.tgz",
+            "integrity": "sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.6",
-                "@babel/helper-module-imports": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/plugin-syntax-jsx": "^7.24.6",
-                "@babel/types": "^7.24.6"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/plugin-syntax-jsx": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -562,12 +568,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx-development": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.24.6.tgz",
-            "integrity": "sha512-F7EsNp5StNDouSSdYyDSxh4J+xvj/JqG+Cb6s2fA+jCyHOzigG5vTwgH8tU2U8Voyiu5zCG9bAK49wTr/wPH0w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.24.7.tgz",
+            "integrity": "sha512-QG9EnzoGn+Qar7rxuW+ZOsbWOt56FvvI93xInqsZDC5fsekx1AlIO4KIJ5M+D0p0SqSH156EpmZyXq630B8OlQ==",
             "dev": true,
             "dependencies": {
-                "@babel/plugin-transform-react-jsx": "^7.24.6"
+                "@babel/plugin-transform-react-jsx": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -577,13 +583,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-pure-annotations": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.24.6.tgz",
-            "integrity": "sha512-0HoDQlFJJkXRyV2N+xOpUETbKHcouSwijRQbKWVtxsPoq5bbB30qZag9/pSc5xcWVYjTHlLsBsY+hZDnzQTPNw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.24.7.tgz",
+            "integrity": "sha512-PLgBVk3fzbmEjBJ/u8kFzOqS9tUeDjiaWud/rRym/yjCo/M9cASPlnrd2ZmmZpQT40fOOrvR8jh+n8jikrOhNA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -593,17 +599,17 @@
             }
         },
         "node_modules/@babel/preset-react": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.24.6.tgz",
-            "integrity": "sha512-8mpzh1bWvmINmwM3xpz6ahu57mNaWavMm+wBNjQ4AFu1nghKBiIRET7l/Wmj4drXany/BBGjJZngICcD98F1iw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.24.7.tgz",
+            "integrity": "sha512-AAH4lEkpmzFWrGVlHaxJB7RLH21uPQ9+He+eFLWHmF9IuFQVugz8eAsamaW0DXRrTfco5zj1wWtpdcXJUOfsag==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-validator-option": "^7.24.6",
-                "@babel/plugin-transform-react-display-name": "^7.24.6",
-                "@babel/plugin-transform-react-jsx": "^7.24.6",
-                "@babel/plugin-transform-react-jsx-development": "^7.24.6",
-                "@babel/plugin-transform-react-pure-annotations": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-validator-option": "^7.24.7",
+                "@babel/plugin-transform-react-display-name": "^7.24.7",
+                "@babel/plugin-transform-react-jsx": "^7.24.7",
+                "@babel/plugin-transform-react-jsx-development": "^7.24.7",
+                "@babel/plugin-transform-react-pure-annotations": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -624,34 +630,34 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/parser": "^7.22.15",
-                "@babel/types": "^7.22.15"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
-            "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+            "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/generator": "^7.23.3",
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.23.3",
-                "@babel/types": "^7.23.3",
-                "debug": "^4.1.0",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.24.7",
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-function-name": "^7.24.7",
+                "@babel/helper-hoist-variables": "^7.24.7",
+                "@babel/helper-split-export-declaration": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7",
+                "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -659,13 +665,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.6.tgz",
-            "integrity": "sha512-WaMsgi6Q8zMgMth93GvWPXkhAIEobfsIkLTacoVZoK1J0CevIPGYY2Vo5YvJGqyHqXM6P4ppOYGsIRU8MM9pFQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.6",
-                "@babel/helper-validator-identifier": "^7.24.6",
+                "@babel/helper-string-parser": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -679,9 +685,9 @@
             "dev": true
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-            "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -694,9 +700,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-            "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
             "cpu": [
                 "arm"
             ],
@@ -709,9 +715,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-            "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
             "cpu": [
                 "arm64"
             ],
@@ -724,9 +730,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-            "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
             "cpu": [
                 "x64"
             ],
@@ -739,9 +745,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-            "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
             "cpu": [
                 "arm64"
             ],
@@ -754,9 +760,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-            "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
             "cpu": [
                 "x64"
             ],
@@ -769,9 +775,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-            "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
             "cpu": [
                 "arm64"
             ],
@@ -784,9 +790,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-            "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
             "cpu": [
                 "x64"
             ],
@@ -799,9 +805,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-            "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
             "cpu": [
                 "arm"
             ],
@@ -814,9 +820,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-            "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
             "cpu": [
                 "arm64"
             ],
@@ -829,9 +835,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-            "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
             "cpu": [
                 "ia32"
             ],
@@ -844,9 +850,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-            "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
             "cpu": [
                 "loong64"
             ],
@@ -859,9 +865,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-            "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
             "cpu": [
                 "mips64el"
             ],
@@ -874,9 +880,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-            "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
             "cpu": [
                 "ppc64"
             ],
@@ -889,9 +895,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-            "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
             "cpu": [
                 "riscv64"
             ],
@@ -904,9 +910,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-            "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
             "cpu": [
                 "s390x"
             ],
@@ -919,9 +925,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-            "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
             "cpu": [
                 "x64"
             ],
@@ -934,9 +940,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-            "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
             "cpu": [
                 "x64"
             ],
@@ -949,9 +955,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-            "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
             "cpu": [
                 "x64"
             ],
@@ -964,9 +970,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-            "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
             "cpu": [
                 "x64"
             ],
@@ -979,9 +985,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-            "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
             "cpu": [
                 "arm64"
             ],
@@ -994,9 +1000,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-            "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
             "cpu": [
                 "ia32"
             ],
@@ -1009,9 +1015,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-            "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
             "cpu": [
                 "x64"
             ],
@@ -2022,9 +2028,10 @@
             }
         },
         "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "devOptional": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -2062,9 +2069,9 @@
             "devOptional": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-            "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "devOptional": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -2072,14 +2079,14 @@
             }
         },
         "node_modules/@navikt/aksel-icons": {
-            "version": "6.10.0",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/6.10.0/d832911d79939b408fddfa1b4da7bac3527f6fe4",
-            "integrity": "sha512-MNjjpNc+wahqQBD4oSj/iIKJQCKZn5rGVh3RmKi95tX/Ta/MRskb807LTVZvq4S1+sOKK4VPgFONf8OertJz9g=="
+            "version": "6.11.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/6.11.0/77b15cf3dd8cd4240862b8bb212a3e94c7b507f8",
+            "integrity": "sha512-7S8C8h5Dc5GQPqJZVlgbBrjMTndn4wwwoIjusg27A3TVXUs94Iy9JyyU1U59h3L58lLYzo/Yb6kSqV3wKtMpZA=="
         },
         "node_modules/@navikt/ds-css": {
-            "version": "6.10.0",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/6.10.0/cd03b719d06e7993980699c2f6cb31795fa91535",
-            "integrity": "sha512-hpuoPzOVT23oDjZlq1NH9f8K9R/n/j3RhTJwiuT5lkpx8xkB/enZ7uc4A3eeyZszontxktZRTQN2KXNN0vhvBg=="
+            "version": "6.11.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/6.11.0/d71f2ada5c3376a5bba21d876604f7b9f946fff3",
+            "integrity": "sha512-G62P4NJ3Yh5ianMxBlgjtpl/0+NG1Nvm5yREZ2A6sOLYn6P0Fv5hZWOoSY+eCfWlkT9JXvzTDoFokQtqrUzflA=="
         },
         "node_modules/@navikt/ds-icons": {
             "version": "3.4.3",
@@ -2092,14 +2099,14 @@
             }
         },
         "node_modules/@navikt/ds-react": {
-            "version": "6.10.0",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/6.10.0/43abd526e58f1641effd0aa76a255a064068b5dd",
-            "integrity": "sha512-o+/MqUQMX++tp3mXe5Vlnu97CmDd+mdxcr8sT8jeLm9Jf3ms52O1hSdKK6NlJFYVBkOtZMH0Rr306n5n7X+VGA==",
+            "version": "6.11.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/6.11.0/d5570c1f831bbf7dfbbd005693f59fe74f67d1ee",
+            "integrity": "sha512-HAwKQpyJ98cKUIsnv/ZBeppJjZt72virxQiJZCCSFdBBWVOajJ4Q9C7gOXbhOZ4yNgPL3NJnPMlnqNe8Ce/hQg==",
             "dependencies": {
                 "@floating-ui/react": "0.25.4",
                 "@floating-ui/react-dom": "^2.0.9",
-                "@navikt/aksel-icons": "^6.10.0",
-                "@navikt/ds-tokens": "^6.10.0",
+                "@navikt/aksel-icons": "^6.11.0",
+                "@navikt/ds-tokens": "^6.11.0",
                 "clsx": "^2.1.0",
                 "date-fns": "^3.0.0",
                 "react-day-picker": "8.10.0"
@@ -2119,9 +2126,9 @@
             }
         },
         "node_modules/@navikt/ds-tokens": {
-            "version": "6.10.0",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/6.10.0/56ae8412d9973f5a844b7a15d95c2ac3e008b171",
-            "integrity": "sha512-wnTS4mirTcTFoptobIp6PfmO8eEHDmt3FNxWAB+AORLOuwVF7Qrfb/zDnAEKBwN381ySSPuFZuQTudJU7hIcfQ=="
+            "version": "6.11.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/6.11.0/ad1fc80e0934e1576e1c1f88a74eb52e40771e9b",
+            "integrity": "sha512-6+NfOyMWEzcq/mRUgVGugDta8LK4a3+lZWq1zTiyKayVQ+ADG4m5YbW1XnN35X+RdsVUxm+kxZa9myeSigwCrQ=="
         },
         "node_modules/@navikt/nav-dekoratoren-moduler": {
             "version": "2.1.6",
@@ -2772,12 +2779,12 @@
             }
         },
         "node_modules/@testing-library/jest-dom": {
-            "version": "6.4.5",
-            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.5.tgz",
-            "integrity": "sha512-AguB9yvTXmCnySBP1lWjfNNUwpbElsaQ567lt2VdGqAdHtpieLgjmcVyv1q7PMIvLbgpDdkWV5Ydv3FEejyp2A==",
+            "version": "6.4.6",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.6.tgz",
+            "integrity": "sha512-8qpnGVincVDLEcQXWaHOf6zmlbwTKc6Us6PPu4CRnPXCzo2OGBS5cwgMMOWdxDpEz1mkbvXHpEy99M5Yvt682w==",
             "dev": true,
             "dependencies": {
-                "@adobe/css-tools": "^4.3.2",
+                "@adobe/css-tools": "^4.4.0",
                 "@babel/runtime": "^7.9.2",
                 "aria-query": "^5.0.0",
                 "chalk": "^3.0.0",
@@ -3152,9 +3159,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.14.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.1.tgz",
-            "integrity": "sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==",
+            "version": "20.14.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.6.tgz",
+            "integrity": "sha512-JbA0XIJPL1IiNnU7PFxDXyfAwcwVVrOoqyzzyQTyMeVhBzkJVMSkC1LlVsRQ2lpqiY4n6Bb9oCS6lzDKVQxbZw==",
             "devOptional": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -3261,16 +3268,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.12.0.tgz",
-            "integrity": "sha512-7F91fcbuDf/d3S8o21+r3ZncGIke/+eWk0EpO21LXhDfLahriZF9CGj4fbAetEjlaBdjdSm9a6VeXbpbT6Z40Q==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.1.tgz",
+            "integrity": "sha512-kZqi+WZQaZfPKnsflLJQCz6Ze9FFSMfXrrIOcyargekQxG37ES7DJNpJUE9Q/X5n3yTIP/WPutVNzgknQ7biLg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "7.12.0",
-                "@typescript-eslint/type-utils": "7.12.0",
-                "@typescript-eslint/utils": "7.12.0",
-                "@typescript-eslint/visitor-keys": "7.12.0",
+                "@typescript-eslint/scope-manager": "7.13.1",
+                "@typescript-eslint/type-utils": "7.13.1",
+                "@typescript-eslint/utils": "7.13.1",
+                "@typescript-eslint/visitor-keys": "7.13.1",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -3293,65 +3300,16 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.12.0.tgz",
-            "integrity": "sha512-lib96tyRtMhLxwauDWUp/uW3FMhLA6D0rJ8T7HmH7x23Gk1Gwwu8UZ94NMXBvOELn6flSPiBrCKlehkiXyaqwA==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/typescript-estree": "7.12.0",
-                "@typescript-eslint/utils": "7.12.0",
-                "debug": "^4.3.4",
-                "ts-api-utils": "^1.3.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || >=20.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.56.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.12.0.tgz",
-            "integrity": "sha512-Y6hhwxwDx41HNpjuYswYp6gDbkiZ8Hin9Bf5aJQn1bpTs3afYY4GX+MPYxma8jtoIV2GRwTM/UJm/2uGCVv+DQ==",
-            "dev": true,
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "7.12.0",
-                "@typescript-eslint/types": "7.12.0",
-                "@typescript-eslint/typescript-estree": "7.12.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || >=20.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.56.0"
-            }
-        },
         "node_modules/@typescript-eslint/parser": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.12.0.tgz",
-            "integrity": "sha512-dm/J2UDY3oV3TKius2OUZIFHsomQmpHtsV0FTh1WO8EKgHLQ1QCADUqscPgTpU+ih1e21FQSRjXckHn3txn6kQ==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.1.tgz",
+            "integrity": "sha512-1ELDPlnLvDQ5ybTSrMhRTFDfOQEOXNM+eP+3HT/Yq7ruWpciQw+Avi73pdEbA4SooCawEWo3dtYbF68gN7Ed1A==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "7.12.0",
-                "@typescript-eslint/types": "7.12.0",
-                "@typescript-eslint/typescript-estree": "7.12.0",
-                "@typescript-eslint/visitor-keys": "7.12.0",
+                "@typescript-eslint/scope-manager": "7.13.1",
+                "@typescript-eslint/types": "7.13.1",
+                "@typescript-eslint/typescript-estree": "7.13.1",
+                "@typescript-eslint/visitor-keys": "7.13.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -3371,13 +3329,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.12.0.tgz",
-            "integrity": "sha512-itF1pTnN6F3unPak+kutH9raIkL3lhH1YRPGgt7QQOh43DQKVJXmWkpb+vpc/TiDHs6RSd9CTbDsc/Y+Ygq7kg==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.1.tgz",
+            "integrity": "sha512-adbXNVEs6GmbzaCpymHQ0MB6E4TqoiVbC0iqG3uijR8ZYfpAXMGttouQzF4Oat3P2GxDVIrg7bMI/P65LiQZdg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "7.12.0",
-                "@typescript-eslint/visitor-keys": "7.12.0"
+                "@typescript-eslint/types": "7.13.1",
+                "@typescript-eslint/visitor-keys": "7.13.1"
             },
             "engines": {
                 "node": "^18.18.0 || >=20.0.0"
@@ -3387,10 +3345,37 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.1.tgz",
+            "integrity": "sha512-aWDbLu1s9bmgPGXSzNCxELu+0+HQOapV/y+60gPXafR8e2g1Bifxzevaa+4L2ytCWm+CHqpELq4CSoN9ELiwCg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "7.13.1",
+                "@typescript-eslint/utils": "7.13.1",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^1.3.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@typescript-eslint/types": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.12.0.tgz",
-            "integrity": "sha512-o+0Te6eWp2ppKY3mLCU+YA9pVJxhUJE15FV7kxuD9jgwIAa+w/ycGJBMrYDTpVGUM/tgpa9SeMOugSabWFq7bg==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.1.tgz",
+            "integrity": "sha512-7K7HMcSQIAND6RBL4kDl24sG/xKM13cA85dc7JnmQXw2cBDngg7c19B++JzvJHRG3zG36n9j1i451GBzRuHchw==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || >=20.0.0"
@@ -3401,13 +3386,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.12.0.tgz",
-            "integrity": "sha512-5bwqLsWBULv1h6pn7cMW5dXX/Y2amRqLaKqsASVwbBHMZSnHqE/HN4vT4fE0aFsiwxYvr98kqOWh1a8ZKXalCQ==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.1.tgz",
+            "integrity": "sha512-uxNr51CMV7npU1BxZzYjoVz9iyjckBduFBP0S5sLlh1tXYzHzgZ3BR9SVsNed+LmwKrmnqN3Kdl5t7eZ5TS1Yw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "7.12.0",
-                "@typescript-eslint/visitor-keys": "7.12.0",
+                "@typescript-eslint/types": "7.13.1",
+                "@typescript-eslint/visitor-keys": "7.13.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -3464,13 +3449,35 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.12.0.tgz",
-            "integrity": "sha512-uZk7DevrQLL3vSnfFl5bj4sL75qC9D6EdjemIdbtkuUmIheWpuiiylSY01JxJE7+zGrOWDZrp1WxOuDntvKrHQ==",
+        "node_modules/@typescript-eslint/utils": {
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.1.tgz",
+            "integrity": "sha512-h5MzFBD5a/Gh/fvNdp9pTfqJAbuQC4sCN2WzuXme71lqFJsZtLbjxfSk4r3p02WIArOF9N94pdsLiGutpDbrXQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "7.12.0",
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@typescript-eslint/scope-manager": "7.13.1",
+                "@typescript-eslint/types": "7.13.1",
+                "@typescript-eslint/typescript-estree": "7.13.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.1.tgz",
+            "integrity": "sha512-k/Bfne7lrP7hcb7m9zSsgcBmo+8eicqqfNAJ7uUY+jkTFpKeH2FSkWpFRtimBxgkyvqfu9jTPRbYOvud6isdXA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "7.13.1",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -3743,16 +3750,19 @@
             }
         },
         "node_modules/array.prototype.tosorted": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.3.tgz",
-            "integrity": "sha512-/DdH4TiTmOKzyQbp/eadcCVexiCb36xJg7HshYOYJnNZFDj33GEv0P7GxsynpShhq4OLYJzbGcBDkLsDt7MnNg==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+            "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.5",
+                "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.22.3",
-                "es-errors": "^1.1.0",
+                "es-abstract": "^1.23.3",
+                "es-errors": "^1.3.0",
                 "es-shim-unscopables": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/arraybuffer.prototype.slice": {
@@ -4036,11 +4046,12 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -4525,16 +4536,6 @@
         "node_modules/cookie-signature": {
             "version": "1.0.6",
             "license": "MIT"
-        },
-        "node_modules/core-js": {
-            "version": "3.27.2",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
         },
         "node_modules/create-jest": {
             "version": "29.7.0",
@@ -5274,9 +5275,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-            "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
             "hasInstallScript": true,
             "bin": {
                 "esbuild": "bin/esbuild"
@@ -5285,29 +5286,29 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.20.2",
-                "@esbuild/android-arm": "0.20.2",
-                "@esbuild/android-arm64": "0.20.2",
-                "@esbuild/android-x64": "0.20.2",
-                "@esbuild/darwin-arm64": "0.20.2",
-                "@esbuild/darwin-x64": "0.20.2",
-                "@esbuild/freebsd-arm64": "0.20.2",
-                "@esbuild/freebsd-x64": "0.20.2",
-                "@esbuild/linux-arm": "0.20.2",
-                "@esbuild/linux-arm64": "0.20.2",
-                "@esbuild/linux-ia32": "0.20.2",
-                "@esbuild/linux-loong64": "0.20.2",
-                "@esbuild/linux-mips64el": "0.20.2",
-                "@esbuild/linux-ppc64": "0.20.2",
-                "@esbuild/linux-riscv64": "0.20.2",
-                "@esbuild/linux-s390x": "0.20.2",
-                "@esbuild/linux-x64": "0.20.2",
-                "@esbuild/netbsd-x64": "0.20.2",
-                "@esbuild/openbsd-x64": "0.20.2",
-                "@esbuild/sunos-x64": "0.20.2",
-                "@esbuild/win32-arm64": "0.20.2",
-                "@esbuild/win32-ia32": "0.20.2",
-                "@esbuild/win32-x64": "0.20.2"
+                "@esbuild/aix-ppc64": "0.21.5",
+                "@esbuild/android-arm": "0.21.5",
+                "@esbuild/android-arm64": "0.21.5",
+                "@esbuild/android-x64": "0.21.5",
+                "@esbuild/darwin-arm64": "0.21.5",
+                "@esbuild/darwin-x64": "0.21.5",
+                "@esbuild/freebsd-arm64": "0.21.5",
+                "@esbuild/freebsd-x64": "0.21.5",
+                "@esbuild/linux-arm": "0.21.5",
+                "@esbuild/linux-arm64": "0.21.5",
+                "@esbuild/linux-ia32": "0.21.5",
+                "@esbuild/linux-loong64": "0.21.5",
+                "@esbuild/linux-mips64el": "0.21.5",
+                "@esbuild/linux-ppc64": "0.21.5",
+                "@esbuild/linux-riscv64": "0.21.5",
+                "@esbuild/linux-s390x": "0.21.5",
+                "@esbuild/linux-x64": "0.21.5",
+                "@esbuild/netbsd-x64": "0.21.5",
+                "@esbuild/openbsd-x64": "0.21.5",
+                "@esbuild/sunos-x64": "0.21.5",
+                "@esbuild/win32-arm64": "0.21.5",
+                "@esbuild/win32-ia32": "0.21.5",
+                "@esbuild/win32-x64": "0.21.5"
             }
         },
         "node_modules/esbuild-android-64": {
@@ -5768,16 +5769,16 @@
             }
         },
         "node_modules/eslint-plugin-react": {
-            "version": "7.34.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.2.tgz",
-            "integrity": "sha512-2HCmrU+/JNigDN6tg55cRDKCQWicYAPB38JGSFDQt95jDm8rrvSUo7YPkOIm5l6ts1j1zCvysNcasvfTMQzUOw==",
+            "version": "7.34.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.3.tgz",
+            "integrity": "sha512-aoW4MV891jkUulwDApQbPYTVZmeuSyFrudpbTAQuj5Fv8VL+o6df2xIGpw8B0hPjAaih1/Fb0om9grCdyFYemA==",
             "dev": true,
             "dependencies": {
                 "array-includes": "^3.1.8",
                 "array.prototype.findlast": "^1.2.5",
                 "array.prototype.flatmap": "^1.3.2",
                 "array.prototype.toreversed": "^1.1.2",
-                "array.prototype.tosorted": "^1.1.3",
+                "array.prototype.tosorted": "^1.1.4",
                 "doctrine": "^2.1.0",
                 "es-iterator-helpers": "^1.0.19",
                 "estraverse": "^5.3.0",
@@ -6218,20 +6219,17 @@
             }
         },
         "node_modules/fetch-mock": {
-            "version": "9.11.0",
+            "version": "10.0.7",
+            "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-10.0.7.tgz",
+            "integrity": "sha512-TFG42kMRJ6dZpUDeVTdXNjh5O4TchHU/UNk41a050TwKzRr5RJQbtckXDjXiQFHPKgXGUG5l2TY3ZZ2gokiXaQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/core": "^7.0.0",
-                "@babel/runtime": "^7.0.0",
-                "core-js": "^3.0.0",
                 "debug": "^4.1.1",
                 "glob-to-regexp": "^0.4.0",
                 "is-subset": "^0.1.1",
                 "lodash.isequal": "^4.5.0",
                 "path-to-regexp": "^2.2.1",
-                "querystring": "^0.2.0",
-                "whatwg-url": "^6.5.0"
+                "querystring": "^0.2.1"
             },
             "engines": {
                 "node": ">=4.0.0"
@@ -6239,9 +6237,6 @@
             "funding": {
                 "type": "charity",
                 "url": "https://www.justgiving.com/refugee-support-europe"
-            },
-            "peerDependencies": {
-                "node-fetch": "2.6.7"
             },
             "peerDependenciesMeta": {
                 "node-fetch": {
@@ -6262,9 +6257,10 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -7161,8 +7157,9 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -9731,11 +9728,6 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
         },
-        "node_modules/lodash.sortby": {
-            "version": "4.7.0",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/long-timeout": {
             "version": "0.1.1",
             "license": "MIT"
@@ -10106,9 +10098,9 @@
             }
         },
         "node_modules/nodemon": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.3.tgz",
-            "integrity": "sha512-m4Vqs+APdKzDFpuaL9F9EVOF85+h070FnkHVEoU4+rmT6Vw0bmNl7s61VEkY/cJkL7RCv1p4urnUDUMrS5rk2w==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.4.tgz",
+            "integrity": "sha512-wjPBbFhtpJwmIeY2yP7QF+UKzPfltVGtfce1g/bB15/8vCGZj8uxD62b/b9M9/WVgme0NZudpownKN+c0plXlQ==",
             "dev": true,
             "dependencies": {
                 "chokidar": "^3.5.2",
@@ -10761,9 +10753,9 @@
             }
         },
         "node_modules/preact-render-to-string": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.4.tgz",
-            "integrity": "sha512-06s0E3cEMLoXQznmtJ/K/xbFs3uwo52Qpgf8lzbe+VbF/XzwJ0LxZGtVLZekhaEeC39+W1MEf05F4lUikzPnxA==",
+            "version": "6.5.5",
+            "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.5.tgz",
+            "integrity": "sha512-KiMFTKNTmT/ccE79BURR/r6XRc2I2TCTZ0MpeWqHW2XnllbeghXvwGsdAfF/MzMilUcTfODtSmMxgoRFL9TM5g==",
             "peerDependencies": {
                 "preact": ">=10"
             }
@@ -10778,9 +10770,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
-            "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+            "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -11932,8 +11924,9 @@
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -11973,14 +11966,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/tr46": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "punycode": "^2.1.0"
-            }
-        },
         "node_modules/tree-kill": {
             "version": "1.2.2",
             "dev": true,
@@ -12002,9 +11987,9 @@
             }
         },
         "node_modules/ts-jest": {
-            "version": "29.1.4",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.4.tgz",
-            "integrity": "sha512-YiHwDhSvCiItoAgsKtoLFCuakDzDsJ1DLDnSouTaTmdOcOwIkSzbLXduaQ6M5DRVhuZC/NYaaZ/mtHbWMv/S6Q==",
+            "version": "29.1.5",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.5.tgz",
+            "integrity": "sha512-UuClSYxM7byvvYfyWdFI+/2UxMmwNyJb0NPkZPQE2hew3RurV7l7zURgOHAd/1I1ZdPpe3GUsXNXAcN8TFKSIg==",
             "dev": true,
             "dependencies": {
                 "bs-logger": "0.x",
@@ -12348,11 +12333,11 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.2.12",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.12.tgz",
-            "integrity": "sha512-/gC8GxzxMK5ntBwb48pR32GGhENnjtY30G4A0jemunsBkiEZFw60s8InGpN8gkhHEkjnRK1aSAxeQgwvFhUHAA==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.1.tgz",
+            "integrity": "sha512-XBmSKRLXLxiaPYamLv3/hnP/KXDai1NDexN0FpkTaZXTfycHvkRHoenpgl/fvuK/kPbB6xAgoyiryAhQNxYmAQ==",
             "dependencies": {
-                "esbuild": "^0.20.1",
+                "esbuild": "^0.21.3",
                 "postcss": "^8.4.38",
                 "rollup": "^4.13.0"
             },
@@ -12466,21 +12451,6 @@
             "engines": {
                 "node": ">=12"
             }
-        },
-        "node_modules/whatwg-url": {
-            "version": "6.5.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lodash.sortby": "^4.7.0",
-                "tr46": "^1.0.1",
-                "webidl-conversions": "^4.0.2"
-            }
-        },
-        "node_modules/whatwg-url/node_modules/webidl-conversions": {
-            "version": "4.0.2",
-            "dev": true,
-            "license": "BSD-2-Clause"
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -12647,9 +12617,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -12739,16 +12709,16 @@
                 "lru-cache": "10.2.2",
                 "node-fetch": "3.3.2",
                 "node-schedule": "2.1.1",
-                "vite": "5.2.12"
+                "vite": "5.3.1"
             },
             "devDependencies": {
                 "@types/compression": "1.7.5",
                 "@types/express": "4.17.21",
                 "@types/lru-cache": "7.10.10",
-                "@types/node": "20.14.1",
+                "@types/node": "20.14.6",
                 "@types/node-schedule": "2.1.7",
                 "concurrently": "8.2.2",
-                "nodemon": "3.1.3"
+                "nodemon": "3.1.4"
             }
         },
         "server/node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -19,31 +19,31 @@
         "server"
     ],
     "dependencies": {
-        "@navikt/ds-css": "6.10.0",
+        "@navikt/ds-css": "6.11.0",
         "@navikt/ds-icons": "3.4.3",
-        "@navikt/ds-react": "6.10.0",
+        "@navikt/ds-react": "6.11.0",
         "@navikt/nav-dekoratoren-moduler": "2.1.6",
         "@preact/compat": "17.1.2",
         "lodash.debounce": "4.0.8",
-        "preact-render-to-string": "6.5.4"
+        "preact-render-to-string": "6.5.5"
     },
     "devDependencies": {
-        "@babel/preset-react": "7.24.6",
+        "@babel/preset-react": "7.24.7",
         "@octokit/core": "6.1.2",
         "@originjs/vite-plugin-commonjs": "1.0.3",
         "@preact/preset-vite": "2.8.2",
-        "@testing-library/jest-dom": "6.4.5",
+        "@testing-library/jest-dom": "6.4.6",
         "@testing-library/react": "16.0.0",
         "@types/jest": "29.5.12",
         "@types/lodash.debounce": "4.0.9",
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
         "@types/react-test-renderer": "18.3.0",
-        "@typescript-eslint/eslint-plugin": "7.12.0",
-        "@typescript-eslint/parser": "7.12.0",
+        "@typescript-eslint/eslint-plugin": "7.13.1",
+        "@typescript-eslint/parser": "7.13.1",
         "eslint": "8.57.0",
-        "eslint-plugin-react": "7.34.2",
-        "fetch-mock": "9.11.0",
+        "eslint-plugin-react": "7.34.3",
+        "fetch-mock": "10.0.7",
         "husky": "9.0.11",
         "identity-obj-proxy": "3.0.0",
         "jest": "29.7.0",
@@ -51,11 +51,11 @@
         "jest-fetch-mock": "3.0.3",
         "node-fetch": "2.6.7",
         "npm-run-all": "4.1.5",
-        "prettier": "3.3.0",
+        "prettier": "3.3.2",
         "react-test-renderer": "18.3.1",
-        "ts-jest": "29.1.4",
+        "ts-jest": "29.1.5",
         "typescript": "5.4.5",
-        "vite": "5.2.12"
+        "vite": "5.3.1"
     },
     "browserslist": {
         "production": [

--- a/server/package.json
+++ b/server/package.json
@@ -17,15 +17,15 @@
         "node-fetch": "3.3.2",
         "node-schedule": "2.1.1",
         "lodash.debounce": "4.0.8",
-        "vite": "5.2.12"
+        "vite": "5.3.1"
     },
     "devDependencies": {
         "@types/compression": "1.7.5",
         "@types/express": "4.17.21",
         "@types/lru-cache": "7.10.10",
-        "@types/node": "20.14.1",
+        "@types/node": "20.14.6",
         "@types/node-schedule": "2.1.7",
         "concurrently": "8.2.2",
-        "nodemon": "3.1.3"
+        "nodemon": "3.1.4"
     }
 }


### PR DESCRIPTION
## Hva er gjort

Oppdatert avhengigheter.

En major: fetch-mock fra 9.11.0 til 10.0.7
Ellers holdes eslint fortsatt på versjon  8.57.0 (9.5.0 nå).

## Testing
Har testet lokalt og i dev.


