### PR TITLE
Bump dependencies 240924

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@navikt/ds-css": "7.0.1",
                 "@navikt/ds-icons": "3.4.3",
                 "@navikt/ds-react": "7.0.1",
-                "@navikt/nav-dekoratoren-moduler": "2.1.6",
+                "@navikt/nav-dekoratoren-moduler": "3.1.0",
                 "@preact/compat": "18.3.1",
                 "lodash.debounce": "4.0.8",
                 "preact-render-to-string": "6.5.11"
@@ -2165,21 +2165,18 @@
             "integrity": "sha512-aMi9G/vIwqAQRX2fwnFehmzNnEfMjuTkzc55nVR50fw0QKa0NXgjuAnIYZGLdNmE4y+fvxCx1uOY+cUBccqFQQ=="
         },
         "node_modules/@navikt/nav-dekoratoren-moduler": {
-            "version": "2.1.6",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/nav-dekoratoren-moduler/2.1.6/049e1daeecff43519e41e387f21fd7e3634c2bd3",
-            "integrity": "sha512-P9c+a8/HuIY6XScNr/DVS7lZ0UtndzYAMEaIVdAzCOrG4SudY4tXSp+44g1V58GKml1RjdzOfGVF4hxmFv3SiA==",
+            "version": "3.1.0",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/nav-dekoratoren-moduler/3.1.0/d0731ed243140296e5d363ecaba39da3e314031e",
+            "integrity": "sha512-Lul6z6U0NQJEnIksLYehoThk89tFDeS06ElHgbF5Q+nJ0qMbwVc5IQIyC93LykHYzzxczy83Q1Gp/iNs9xmgqw==",
             "license": "MIT",
-            "dependencies": {
-                "csp-header": "^5.1.0",
-                "html-react-parser": "^3.0.16",
-                "node-cache": "^5.1.2"
-            },
             "engines": {
                 "node": ">=18"
             },
             "peerDependencies": {
+                "csp-header": ">=5.x",
+                "html-react-parser": ">=5.x",
                 "jsdom": ">=16.x",
-                "react": "17.x || 18.x"
+                "react": ">=17.x"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -2949,6 +2946,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
             "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "dev": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -3521,6 +3519,7 @@
         },
         "node_modules/abab": {
             "version": "2.0.6",
+            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/abbrev": {
@@ -3543,6 +3542,7 @@
             "version": "8.12.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
             "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+            "devOptional": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3554,6 +3554,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
             "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+            "dev": true,
             "dependencies": {
                 "acorn": "^8.1.0",
                 "acorn-walk": "^8.0.2"
@@ -3572,12 +3573,14 @@
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
             "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
         },
         "node_modules/agent-base": {
             "version": "6.0.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "4"
@@ -4288,6 +4291,8 @@
         },
         "node_modules/clone": {
             "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+            "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.8"
@@ -4689,8 +4694,11 @@
             }
         },
         "node_modules/csp-header": {
-            "version": "5.1.0",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/csp-header/-/csp-header-5.2.1.tgz",
+            "integrity": "sha512-qOJNu39JZkPrbrAM40a1tQCePEPYVIoI6nMDhX4RA07QjU8efS+zyd/zE83XJu85KKazH9NjKlvvlswFMteMgg==",
             "license": "WTFPL",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -4758,42 +4766,54 @@
             }
         },
         "node_modules/data-urls": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
-            "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "abab": "^2.0.6",
-                "whatwg-mimetype": "^3.0.0",
-                "whatwg-url": "^12.0.0"
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             }
         },
         "node_modules/data-urls/node_modules/tr46": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-            "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+            "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "punycode": "^2.3.0"
+                "punycode": "^2.3.1"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/data-urls/node_modules/whatwg-url": {
-            "version": "12.0.1",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
-            "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+            "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "tr46": "^4.1.1",
+                "tr46": "^5.0.0",
                 "webidl-conversions": "^7.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             }
         },
         "node_modules/data-view-buffer": {
@@ -4898,6 +4918,7 @@
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/deepmerge": {
@@ -5028,6 +5049,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
             "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+            "dev": true,
             "dependencies": {
                 "webidl-conversions": "^7.0.0"
             },
@@ -5678,6 +5700,7 @@
         },
         "node_modules/escodegen": {
             "version": "2.0.0",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "esprima": "^4.0.1",
@@ -5698,6 +5721,7 @@
         },
         "node_modules/escodegen/node_modules/levn": {
             "version": "0.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prelude-ls": "~1.1.2",
@@ -5709,6 +5733,7 @@
         },
         "node_modules/escodegen/node_modules/optionator": {
             "version": "0.8.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "deep-is": "~0.1.3",
@@ -5724,12 +5749,14 @@
         },
         "node_modules/escodegen/node_modules/prelude-ls": {
             "version": "1.1.2",
+            "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
         },
         "node_modules/escodegen/node_modules/type-check": {
             "version": "0.3.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prelude-ls": "~1.1.2"
@@ -6019,6 +6046,7 @@
         },
         "node_modules/esprima": {
             "version": "4.0.1",
+            "dev": true,
             "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
@@ -6054,6 +6082,7 @@
         },
         "node_modules/estraverse": {
             "version": "5.3.0",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
@@ -6067,6 +6096,7 @@
         },
         "node_modules/esutils": {
             "version": "2.0.3",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -6221,6 +6251,7 @@
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fastq": {
@@ -6749,18 +6780,21 @@
             "license": "ISC"
         },
         "node_modules/html-dom-parser": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-3.1.7.tgz",
-            "integrity": "sha512-cDgNF4YgF6J3H+d9mcldGL19p0GzVdS3iGuDNzYWQpU47q3+IRM85X3Xo07E+nntF4ek4s78A9V24EwxlPTjig==",
+            "version": "5.0.10",
+            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.10.tgz",
+            "integrity": "sha512-GwArYL3V3V8yU/mLKoFF7HlLBv80BZ2Ey1BzfVNRpAci0cEKhFHI/Qh8o8oyt3qlAMLlK250wsxLdYX4viedvg==",
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "domhandler": "5.0.3",
-                "htmlparser2": "8.0.2"
+                "htmlparser2": "9.1.0"
             }
         },
         "node_modules/html-encoding-sniffer": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
             "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+            "dev": true,
             "dependencies": {
                 "whatwg-encoding": "^2.0.0"
             },
@@ -6775,23 +6809,31 @@
             "dev": true
         },
         "node_modules/html-react-parser": {
-            "version": "3.0.16",
-            "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-3.0.16.tgz",
-            "integrity": "sha512-ysQZtRFPcg+McVb4B05oNWSnqM14zagpvTgGcI5e1/BvCl38YwzWzKibrbBmXeemg70olN1bAoeixo7o06G5Eg==",
+            "version": "5.1.16",
+            "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.1.16.tgz",
+            "integrity": "sha512-OtVPEQRwa4eelyMbHmUfMSw5VwJsVGSVsfa8I+M8xuV87n91cF3PHpvT/z0Frf1uG34atqh3dxgjaGIsmqVsRA==",
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "domhandler": "5.0.3",
-                "html-dom-parser": "3.1.7",
-                "react-property": "2.0.0",
-                "style-to-js": "1.1.3"
+                "html-dom-parser": "5.0.10",
+                "react-property": "2.0.2",
+                "style-to-js": "1.1.14"
             },
             "peerDependencies": {
+                "@types/react": "0.14 || 15 || 16 || 17 || 18",
                 "react": "0.14 || 15 || 16 || 17 || 18"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/htmlparser2": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+            "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -6799,11 +6841,13 @@
                     "url": "https://github.com/sponsors/fb55"
                 }
             ],
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.3",
-                "domutils": "^3.0.1",
-                "entities": "^4.4.0"
+                "domutils": "^3.1.0",
+                "entities": "^4.5.0"
             }
         },
         "node_modules/http-errors": {
@@ -6825,6 +6869,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dev": true,
             "dependencies": {
                 "@tootallnate/once": "2",
                 "agent-base": "6",
@@ -6836,6 +6881,7 @@
         },
         "node_modules/https-proxy-agent": {
             "version": "5.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "6",
@@ -6972,9 +7018,11 @@
             "license": "ISC"
         },
         "node_modules/inline-style-parser": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
-            "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.3.tgz",
+            "integrity": "sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/internal-slot": {
             "version": "1.0.7",
@@ -9619,43 +9667,39 @@
             }
         },
         "node_modules/jsdom": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.1.tgz",
-            "integrity": "sha512-Jjgdmw48RKcdAIQyUD1UdBh2ecH7VqwaXPN3ehoZN6MqgVbMn+lRm1aAT1AsdJRAJpwfa4IpwgzySn61h2qu3w==",
+            "version": "25.0.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+            "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "abab": "^2.0.6",
-                "acorn": "^8.8.2",
-                "acorn-globals": "^7.0.0",
-                "cssstyle": "^3.0.0",
-                "data-urls": "^4.0.0",
+                "cssstyle": "^4.1.0",
+                "data-urls": "^5.0.0",
                 "decimal.js": "^10.4.3",
-                "domexception": "^4.0.0",
-                "escodegen": "^2.0.0",
                 "form-data": "^4.0.0",
-                "html-encoding-sniffer": "^3.0.0",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.1",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.5",
                 "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.2",
+                "nwsapi": "^2.2.12",
                 "parse5": "^7.1.2",
-                "rrweb-cssom": "^0.6.0",
+                "rrweb-cssom": "^0.7.1",
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
-                "tough-cookie": "^4.1.2",
-                "w3c-xmlserializer": "^4.0.0",
+                "tough-cookie": "^5.0.0",
+                "w3c-xmlserializer": "^5.0.0",
                 "webidl-conversions": "^7.0.0",
-                "whatwg-encoding": "^2.0.0",
-                "whatwg-mimetype": "^3.0.0",
-                "whatwg-url": "^12.0.1",
-                "ws": "^8.13.0",
-                "xml-name-validator": "^4.0.0"
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0",
+                "ws": "^8.18.0",
+                "xml-name-validator": "^5.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             },
             "peerDependencies": {
-                "canvas": "^2.5.0"
+                "canvas": "^2.11.2"
             },
             "peerDependenciesMeta": {
                 "canvas": {
@@ -9663,41 +9707,170 @@
                 }
             }
         },
-        "node_modules/jsdom/node_modules/cssstyle": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
-            "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
+        "node_modules/jsdom/node_modules/agent-base": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "rrweb-cssom": "^0.6.0"
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">= 14"
+            }
+        },
+        "node_modules/jsdom/node_modules/cssstyle": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.1.0.tgz",
+            "integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "rrweb-cssom": "^0.7.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jsdom/node_modules/html-encoding-sniffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "whatwg-encoding": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jsdom/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/jsdom/node_modules/https-proxy-agent": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/jsdom/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/jsdom/node_modules/tough-cookie": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+            "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "dependencies": {
+                "tldts": "^6.1.32"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/jsdom/node_modules/tr46": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-            "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+            "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "punycode": "^2.3.0"
+                "punycode": "^2.3.1"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
+            }
+        },
+        "node_modules/jsdom/node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jsdom/node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jsdom/node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/jsdom/node_modules/whatwg-url": {
-            "version": "12.0.1",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
-            "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+            "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "tr46": "^4.1.1",
+                "tr46": "^5.0.0",
                 "webidl-conversions": "^7.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
+            }
+        },
+        "node_modules/jsdom/node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/jsesc": {
@@ -10137,6 +10310,8 @@
         },
         "node_modules/node-cache": {
             "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+            "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
             "license": "MIT",
             "dependencies": {
                 "clone": "2.x"
@@ -10425,7 +10600,9 @@
             }
         },
         "node_modules/nwsapi": {
-            "version": "2.2.2",
+            "version": "2.2.12",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
+            "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
             "license": "MIT"
         },
         "node_modules/object-assign": {
@@ -10920,6 +11097,7 @@
         },
         "node_modules/psl": {
             "version": "1.9.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/pstree.remy": {
@@ -10928,7 +11106,9 @@
             "license": "MIT"
         },
         "node_modules/punycode": {
-            "version": "2.3.0",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -10966,6 +11146,7 @@
         },
         "node_modules/querystringify": {
             "version": "2.2.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/queue-microtask": {
@@ -11053,9 +11234,11 @@
             "license": "MIT"
         },
         "node_modules/react-property": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
-            "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+            "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/react-shallow-renderer": {
             "version": "16.15.0",
@@ -11201,6 +11384,7 @@
         },
         "node_modules/requires-port": {
             "version": "1.0.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/resolve": {
@@ -11303,9 +11487,10 @@
             }
         },
         "node_modules/rrweb-cssom": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-            "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+            "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/run-parallel": {
@@ -11916,19 +12101,23 @@
             }
         },
         "node_modules/style-to-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.3.tgz",
-            "integrity": "sha512-zKI5gN/zb7LS/Vm0eUwjmjrXWw8IMtyA8aPBJZdYiQTXj4+wQ3IucOLIOnF7zCHxvW8UhIGh/uZh/t9zEHXNTQ==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.14.tgz",
+            "integrity": "sha512-+FGNddHGLPY4NOPneEEdFj8dIy+oV4mHGrPZpB38P+YXrCAG9mp70dbcsAWnM8BFZULkJRvMqD0CXRjZLOYJFA==",
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "style-to-object": "0.4.1"
+                "style-to-object": "1.0.7"
             }
         },
         "node_modules/style-to-object": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
-            "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.7.tgz",
+            "integrity": "sha512-uSjr59G5u6fbxUfKbb8GcqMGT3Xs9v5IbPkjb0S16GyOeBLAzSRK0CixBv5YrYvzO6TDLzIS6QCn78tkqWngPw==",
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "inline-style-parser": "0.1.1"
+                "inline-style-parser": "0.2.3"
             }
         },
         "node_modules/supports-color": {
@@ -12008,6 +12197,26 @@
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
         },
+        "node_modules/tldts": {
+            "version": "6.1.47",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.47.tgz",
+            "integrity": "sha512-R/K2tZ5MiY+mVrnSkNJkwqYT2vUv1lcT6wJvd2emGaMJ7PHUGRY4e3tUsdFCXgqxi2QgbHjL3yJgXCo40v9Hxw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "tldts-core": "^6.1.47"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.47",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.47.tgz",
+            "integrity": "sha512-6SWyFMnlst1fEt7GQVAAu16EGgFK0cLouH/2Mk6Ftlwhv3Ol40L0dlpGMcnnNiiOMyD2EV/aF3S+U2nKvvLvrA==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -12057,6 +12266,7 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
             "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+            "dev": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -12311,6 +12521,7 @@
         },
         "node_modules/universalify": {
             "version": "0.2.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4.0.0"
@@ -12365,6 +12576,7 @@
         },
         "node_modules/url-parse": {
             "version": "1.5.10",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "querystringify": "^2.1.1",
@@ -12470,6 +12682,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
             "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+            "dev": true,
             "dependencies": {
                 "xml-name-validator": "^4.0.0"
             },
@@ -12506,6 +12719,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
             "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+            "dev": true,
             "dependencies": {
                 "iconv-lite": "0.6.3"
             },
@@ -12517,6 +12731,7 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -12528,6 +12743,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
             "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "dev": true,
             "engines": {
                 "node": ">=12"
             }
@@ -12644,6 +12860,7 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12713,9 +12930,10 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -12736,6 +12954,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
             "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+            "dev": true,
             "engines": {
                 "node": ">=12"
             }
@@ -12803,6 +13022,7 @@
                 "express": "4.21.0",
                 "lodash.debounce": "4.0.8",
                 "lru-cache": "11.0.1",
+                "node-cache": "^5.1.2",
                 "node-fetch": "3.3.2",
                 "node-schedule": "2.1.1",
                 "vite": "5.4.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,32 +11,32 @@
                 "server"
             ],
             "dependencies": {
-                "@navikt/ds-css": "6.16.2",
+                "@navikt/ds-css": "7.0.1",
                 "@navikt/ds-icons": "3.4.3",
-                "@navikt/ds-react": "6.16.2",
+                "@navikt/ds-react": "7.0.1",
                 "@navikt/nav-dekoratoren-moduler": "2.1.6",
-                "@preact/compat": "17.1.2",
+                "@preact/compat": "18.3.1",
                 "lodash.debounce": "4.0.8",
-                "preact-render-to-string": "6.5.9"
+                "preact-render-to-string": "6.5.11"
             },
             "devDependencies": {
                 "@babel/preset-react": "7.24.7",
                 "@octokit/core": "6.1.2",
                 "@originjs/vite-plugin-commonjs": "1.0.3",
-                "@preact/preset-vite": "2.9.0",
+                "@preact/preset-vite": "2.9.1",
                 "@testing-library/jest-dom": "6.5.0",
-                "@testing-library/react": "16.0.0",
-                "@types/jest": "29.5.12",
+                "@testing-library/react": "16.0.1",
+                "@types/jest": "29.5.13",
                 "@types/lodash.debounce": "4.0.9",
-                "@types/react": "18.3.4",
+                "@types/react": "18.3.8",
                 "@types/react-dom": "18.3.0",
                 "@types/react-test-renderer": "18.3.0",
-                "@typescript-eslint/eslint-plugin": "8.2.0",
-                "@typescript-eslint/parser": "8.2.0",
-                "eslint": "9.9.1",
-                "eslint-plugin-react": "7.35.0",
-                "fetch-mock": "11.1.1",
-                "husky": "9.1.5",
+                "@typescript-eslint/eslint-plugin": "8.7.0",
+                "@typescript-eslint/parser": "8.7.0",
+                "eslint": "9.11.1",
+                "eslint-plugin-react": "7.36.1",
+                "fetch-mock": "11.1.4",
+                "husky": "9.1.6",
                 "identity-obj-proxy": "3.0.0",
                 "jest": "29.7.0",
                 "jest-environment-jsdom": "29.7.0",
@@ -46,8 +46,8 @@
                 "prettier": "3.3.3",
                 "react-test-renderer": "18.3.1",
                 "ts-jest": "29.2.5",
-                "typescript": "5.5.4",
-                "vite": "5.4.2"
+                "typescript": "5.6.2",
+                "vite": "5.4.7"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -1067,6 +1067,15 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@eslint/core": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.6.0.tgz",
+            "integrity": "sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
@@ -1103,9 +1112,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.9.1.tgz",
-            "integrity": "sha512-xIDQRsfg5hNBqHz04H1R3scSVwmI+KUbqjsQKHKQ1DAUSaUjYPReZZmS/5PNiKu1fUvzDd6H7DEDKACSEhu+TQ==",
+            "version": "9.11.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.1.tgz",
+            "integrity": "sha512-/qu+TWz8WwPWc7/HcIJKi+c+MOm46GdVaSlTTQcaqaL53+GsoA6MxWp5PtTx48qbSP7ylM1Kn7nhvkugfJvRSA==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1116,6 +1125,18 @@
             "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
             "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
             "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/plugin-kit": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
+            "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+            "dev": true,
+            "dependencies": {
+                "levn": "^0.4.1"
+            },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -2092,14 +2113,14 @@
             }
         },
         "node_modules/@navikt/aksel-icons": {
-            "version": "6.16.2",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/6.16.2/9ee0592457a1e1bc8c1990d1aa3a3cf6c9cc4522",
-            "integrity": "sha512-M2rJHEYbHeh9M8smGizRvV6QAj6CAfQMW4vF6zBiNUzV4LfcwgxmwTRM/F5A1lbZScPuFZqAHUey1N3htVl8Cw=="
+            "version": "7.0.1",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/7.0.1/e577737bb8025322cbe3a147cd33ad0e1ce35732",
+            "integrity": "sha512-5atdxy8VCgGTG5t1j5niaR/xLH9Z/sghvVQdeUjEOqF/6FQYbYsQdwGWa3UCkExWQk6n1yHuj2mFbM756adZfg=="
         },
         "node_modules/@navikt/ds-css": {
-            "version": "6.16.2",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/6.16.2/6504d11c7905723a585a2c9ba2555fb5a8a159e1",
-            "integrity": "sha512-fWJRierHeHKe718crx8+TmRsKfQ+BODm13oodvt3LIiQmINNNdF7rtAFSO6+yzF6ReVj2bAnqyr+6UqDH9RJyw=="
+            "version": "7.0.1",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/7.0.1/aa975b0014976ba552205e4fbd5ff68b886d6b93",
+            "integrity": "sha512-IAgJ2AessJbul3JE3DWq2AIfn7MgaF+sZg6W6+ren/S/X5o88KwrqWMqYCxcSf0xaRd9ceVLmJ6W5QOt9fJ4wQ=="
         },
         "node_modules/@navikt/ds-icons": {
             "version": "3.4.3",
@@ -2112,14 +2133,14 @@
             }
         },
         "node_modules/@navikt/ds-react": {
-            "version": "6.16.2",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/6.16.2/b16cba0f95df6b9e4035099c0dc5b239dcbd5392",
-            "integrity": "sha512-snJnxUXiDN8wmjb3uoELhTfpdsdpftXuZBaZeLsST/skMPJHdym9D8pVjbti4pKrnG2/9zYI2rX/bE2e26D7CQ==",
+            "version": "7.0.1",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/7.0.1/fe247ebc8a957b2b677e25a019ba9a9831f4e704",
+            "integrity": "sha512-6pAccYY5Tww59Vd3sraHNAqGdB03ugcDc1g8UIfohyxVkKaXImJ5mLLwzD/O5NewO0xdD0Lne692fN/rGz+xog==",
             "dependencies": {
                 "@floating-ui/react": "0.25.4",
                 "@floating-ui/react-dom": "^2.0.9",
-                "@navikt/aksel-icons": "^6.16.2",
-                "@navikt/ds-tokens": "^6.16.2",
+                "@navikt/aksel-icons": "^7.0.1",
+                "@navikt/ds-tokens": "^7.0.1",
                 "clsx": "^2.1.0",
                 "date-fns": "^3.0.0",
                 "react-day-picker": "8.10.0"
@@ -2139,9 +2160,9 @@
             }
         },
         "node_modules/@navikt/ds-tokens": {
-            "version": "6.16.2",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/6.16.2/e2f8b1ee8b5125a4497d1baca3b19ac4bd6716e4",
-            "integrity": "sha512-2m1CNuP2Uz3mLBQt5Xb1fKziJTrrMw97E6HgICrUCkm2Vo5ZpzkD1tcS0KSlbz1XMg/q+CheERUIL6kPdj79eQ=="
+            "version": "7.0.1",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/7.0.1/476acfd2558df6284de7915317e227afbe3176c0",
+            "integrity": "sha512-aMi9G/vIwqAQRX2fwnFehmzNnEfMjuTkzc55nVR50fw0QKa0NXgjuAnIYZGLdNmE4y+fvxCx1uOY+cUBccqFQQ=="
         },
         "node_modules/@navikt/nav-dekoratoren-moduler": {
             "version": "2.1.6",
@@ -2366,16 +2387,17 @@
             }
         },
         "node_modules/@preact/compat": {
-            "version": "17.1.2",
-            "license": "MIT",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/@preact/compat/-/compat-18.3.1.tgz",
+            "integrity": "sha512-Kog4PSRxtT4COtOXjsuQPV1vMXpUzREQfv+6Dmcy9/rMk0HOPK0HTE9fspFjAmY8R80T/T8gtgmZ68u5bOSngw==",
             "peerDependencies": {
                 "preact": "*"
             }
         },
         "node_modules/@preact/preset-vite": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.9.0.tgz",
-            "integrity": "sha512-B9yVT7AkR6owrt84K3pLNyaKSvlioKdw65VqE/zMiR6HMovPekpsrwBNs5DJhBFEd5cvLMtCjHNHZ9P7Oblveg==",
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.9.1.tgz",
+            "integrity": "sha512-JecWzrOx7ogFhklSMhY+aH/24pajL0Vx+beEgau3WDMUUAo32cpUo/UqerPhLOyhCKXlxK9a3cRoa8g68ZAp5g==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.22.13",
@@ -2388,7 +2410,6 @@
                 "kolorist": "^1.8.0",
                 "magic-string": "0.30.5",
                 "node-html-parser": "^6.1.10",
-                "resolve": "^1.22.8",
                 "source-map": "^0.7.4",
                 "stack-trace": "^1.0.0-pre2"
             },
@@ -2898,9 +2919,9 @@
             }
         },
         "node_modules/@testing-library/react": {
-            "version": "16.0.0",
-            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.0.tgz",
-            "integrity": "sha512-guuxUKRWQ+FgNX0h0NS0FIq3Q3uLtWVpBzcLOggmfMoUpgBnzBzvLLd4fbm6yS8ydJd94cIfY4yP9qUQjM2KwQ==",
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.1.tgz",
+            "integrity": "sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==",
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.5"
@@ -3083,9 +3104,9 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "29.5.12",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
-            "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+            "version": "29.5.13",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.13.tgz",
+            "integrity": "sha512-wd+MVEZCHt23V0/L642O5APvspWply/rGY5BcW4SUETo2UzPU3Z26qr8jC2qxpimI2jjx9h7+2cj2FwIr01bXg==",
             "dev": true,
             "dependencies": {
                 "expect": "^29.0.0",
@@ -3135,6 +3156,12 @@
                 "parse5": "^7.0.0"
             }
         },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true
+        },
         "node_modules/@types/lodash": {
             "version": "4.14.191",
             "dev": true,
@@ -3166,12 +3193,12 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.14.12",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
-            "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
+            "version": "22.6.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.6.1.tgz",
+            "integrity": "sha512-V48tCfcKb/e6cVUigLAaJDAILdMP0fUW6BidkPK4GpGjXcfbnoHasCZDwz3N3yVt5we2RHm4XTQCpv0KJz9zqw==",
             "devOptional": true,
             "dependencies": {
-                "undici-types": "~5.26.4"
+                "undici-types": "~6.19.2"
             }
         },
         "node_modules/@types/node-schedule": {
@@ -3200,9 +3227,9 @@
             "dev": true
         },
         "node_modules/@types/react": {
-            "version": "18.3.4",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
-            "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
+            "version": "18.3.8",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.8.tgz",
+            "integrity": "sha512-syBUrW3/XpnW4WJ41Pft+I+aPoDVbrBVQGEnbD7NijDGlVC+8gV/XKRY+7vMDlfPpbwYt0l1vd/Sj8bJGMbs9Q==",
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -3275,16 +3302,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.2.0.tgz",
-            "integrity": "sha512-02tJIs655em7fvt9gps/+4k4OsKULYGtLBPJfOsmOq1+3cdClYiF0+d6mHu6qDnTcg88wJBkcPLpQhq7FyDz0A==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
+            "integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.2.0",
-                "@typescript-eslint/type-utils": "8.2.0",
-                "@typescript-eslint/utils": "8.2.0",
-                "@typescript-eslint/visitor-keys": "8.2.0",
+                "@typescript-eslint/scope-manager": "8.7.0",
+                "@typescript-eslint/type-utils": "8.7.0",
+                "@typescript-eslint/utils": "8.7.0",
+                "@typescript-eslint/visitor-keys": "8.7.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -3308,15 +3335,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.2.0.tgz",
-            "integrity": "sha512-j3Di+o0lHgPrb7FxL3fdEy6LJ/j2NE8u+AP/5cQ9SKb+JLH6V6UHDqJ+e0hXBkHP1wn1YDFjYCS9LBQsZDlDEg==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
+            "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.2.0",
-                "@typescript-eslint/types": "8.2.0",
-                "@typescript-eslint/typescript-estree": "8.2.0",
-                "@typescript-eslint/visitor-keys": "8.2.0",
+                "@typescript-eslint/scope-manager": "8.7.0",
+                "@typescript-eslint/types": "8.7.0",
+                "@typescript-eslint/typescript-estree": "8.7.0",
+                "@typescript-eslint/visitor-keys": "8.7.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -3336,13 +3363,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.2.0.tgz",
-            "integrity": "sha512-OFn80B38yD6WwpoHU2Tz/fTz7CgFqInllBoC3WP+/jLbTb4gGPTy9HBSTsbDWkMdN55XlVU0mMDYAtgvlUspGw==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
+            "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.2.0",
-                "@typescript-eslint/visitor-keys": "8.2.0"
+                "@typescript-eslint/types": "8.7.0",
+                "@typescript-eslint/visitor-keys": "8.7.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3353,13 +3380,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.2.0.tgz",
-            "integrity": "sha512-g1CfXGFMQdT5S+0PSO0fvGXUaiSkl73U1n9LTK5aRAFnPlJ8dLKkXr4AaLFvPedW8lVDoMgLLE3JN98ZZfsj0w==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
+            "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.2.0",
-                "@typescript-eslint/utils": "8.2.0",
+                "@typescript-eslint/typescript-estree": "8.7.0",
+                "@typescript-eslint/utils": "8.7.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -3377,9 +3404,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.2.0.tgz",
-            "integrity": "sha512-6a9QSK396YqmiBKPkJtxsgZZZVjYQ6wQ/TlI0C65z7vInaETuC6HAHD98AGLC8DyIPqHytvNuS8bBVvNLKyqvQ==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
+            "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3390,15 +3417,15 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.2.0.tgz",
-            "integrity": "sha512-kiG4EDUT4dImplOsbh47B1QnNmXSoUqOjWDvCJw/o8LgfD0yr7k2uy54D5Wm0j4t71Ge1NkynGhpWdS0dEIAUA==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
+            "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.2.0",
-                "@typescript-eslint/visitor-keys": "8.2.0",
+                "@typescript-eslint/types": "8.7.0",
+                "@typescript-eslint/visitor-keys": "8.7.0",
                 "debug": "^4.3.4",
-                "globby": "^11.1.0",
+                "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
                 "minimatch": "^9.0.4",
                 "semver": "^7.6.0",
@@ -3454,15 +3481,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.2.0.tgz",
-            "integrity": "sha512-O46eaYKDlV3TvAVDNcoDzd5N550ckSe8G4phko++OCSC1dYIb9LTc3HDGYdWqWIAT5qDUKphO6sd9RrpIJJPfg==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
+            "integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.2.0",
-                "@typescript-eslint/types": "8.2.0",
-                "@typescript-eslint/typescript-estree": "8.2.0"
+                "@typescript-eslint/scope-manager": "8.7.0",
+                "@typescript-eslint/types": "8.7.0",
+                "@typescript-eslint/typescript-estree": "8.7.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3476,12 +3503,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.2.0.tgz",
-            "integrity": "sha512-sbgsPMW9yLvS7IhCi8IpuK1oBmtbWUNP+hBdwl/I9nzqVsszGnNGti5r9dUtF5RLivHUFFIdRvLiTsPhzSyJ3Q==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
+            "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/types": "8.7.0",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -3686,15 +3713,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/array.prototype.findlast": {
@@ -3987,9 +4005,9 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+            "version": "1.20.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
             "dependencies": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.5",
@@ -3999,7 +4017,7 @@
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
@@ -4382,17 +4400,15 @@
             "license": "MIT"
         },
         "node_modules/concurrently": {
-            "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
-            "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.0.1.tgz",
+            "integrity": "sha512-wYKvCd/f54sTXJMSfV6Ln/B8UrfLBKOYa+lzc6CHay3Qek+LorVSBdMVfyewFhRbH0Rbabsk4D+3PL/VjQ5gzg==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.1.2",
-                "date-fns": "^2.30.0",
                 "lodash": "^4.17.21",
                 "rxjs": "^7.8.1",
                 "shell-quote": "^1.8.1",
-                "spawn-command": "0.0.2",
                 "supports-color": "^8.1.1",
                 "tree-kill": "^1.2.2",
                 "yargs": "^17.7.2"
@@ -4402,7 +4418,7 @@
                 "concurrently": "dist/bin/concurrently.js"
             },
             "engines": {
-                "node": "^14.13.0 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
@@ -4835,6 +4851,7 @@
             "version": "2.30.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
             "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.21.0"
             },
@@ -4934,7 +4951,8 @@
         },
         "node_modules/depd": {
             "version": "2.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -4950,7 +4968,8 @@
         },
         "node_modules/destroy": {
             "version": "1.2.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
@@ -4972,18 +4991,6 @@
             "dev": true,
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "dependencies": {
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/dom-accessibility-api": {
@@ -5068,7 +5075,8 @@
         },
         "node_modules/ee-first": {
             "version": "1.1.1",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
         "node_modules/ejs": {
             "version": "3.1.10",
@@ -5109,8 +5117,9 @@
             "license": "MIT"
         },
         "node_modules/encodeurl": {
-            "version": "1.0.2",
-            "license": "MIT",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -5656,7 +5665,8 @@
         },
         "node_modules/escape-html": {
             "version": "1.0.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
         },
         "node_modules/escape-string-regexp": {
             "version": "1.0.5",
@@ -5729,19 +5739,23 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.9.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.9.1.tgz",
-            "integrity": "sha512-dHvhrbfr4xFQ9/dq+jcVneZMyRYLjggWjk6RVsIiHsP8Rz6yZ8LvZ//iU4TrZF+SXWG+JkNF2OyiZRvzgRDqMg==",
+            "version": "9.11.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.1.tgz",
+            "integrity": "sha512-MobhYKIoAO1s1e4VUrgx1l1Sk2JBR/Gqjjgw8+mfgoLE2xwsHur4gdfTxyTgShrhvdVFTaJSgMiQBl1jv/AWxg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.11.0",
                 "@eslint/config-array": "^0.18.0",
+                "@eslint/core": "^0.6.0",
                 "@eslint/eslintrc": "^3.1.0",
-                "@eslint/js": "9.9.1",
+                "@eslint/js": "9.11.1",
+                "@eslint/plugin-kit": "^0.2.0",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.3.0",
                 "@nodelib/fs.walk": "^1.2.8",
+                "@types/estree": "^1.0.6",
+                "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -5761,7 +5775,6 @@
                 "is-glob": "^4.0.0",
                 "is-path-inside": "^3.0.3",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
@@ -5788,9 +5801,9 @@
             }
         },
         "node_modules/eslint-plugin-react": {
-            "version": "7.35.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.35.0.tgz",
-            "integrity": "sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==",
+            "version": "7.36.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.36.1.tgz",
+            "integrity": "sha512-/qwbqNXZoq+VP30s1d4Nc1C5GTxjJQjk4Jzs4Wq2qzxFM7dSmuG2UkIjg2USMLh3A/aVcUNrK7v0J5U1XEGGwA==",
             "dev": true,
             "dependencies": {
                 "array-includes": "^3.1.8",
@@ -5874,6 +5887,12 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
+        },
+        "node_modules/eslint/node_modules/@types/estree": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "dev": true
         },
         "node_modules/eslint/node_modules/ansi-styles": {
             "version": "4.3.0",
@@ -6055,7 +6074,8 @@
         },
         "node_modules/etag": {
             "version": "1.8.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -6109,36 +6129,36 @@
             }
         },
         "node_modules/express": {
-            "version": "4.19.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-            "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+            "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.2",
+                "body-parser": "1.20.3",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "0.6.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
+                "finalhandler": "1.3.1",
                 "fresh": "0.5.2",
                 "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
+                "merge-descriptors": "1.0.3",
                 "methods": "~1.1.2",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
+                "path-to-regexp": "0.1.10",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
+                "send": "0.19.0",
+                "serve-static": "1.16.2",
                 "setprototypeof": "1.2.0",
                 "statuses": "2.0.1",
                 "type-is": "~1.6.18",
@@ -6158,10 +6178,6 @@
         },
         "node_modules/express/node_modules/ms": {
             "version": "2.0.0",
-            "license": "MIT"
-        },
-        "node_modules/express/node_modules/path-to-regexp": {
-            "version": "0.1.7",
             "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
@@ -6247,9 +6263,9 @@
             }
         },
         "node_modules/fetch-mock": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-11.1.1.tgz",
-            "integrity": "sha512-2lZ42bnMar9MBfNR0nza5wM4ZDwLxb+ZbNR4sEvpqOOBzZ+V6cZVVhLBHj8+AAEInF4vp2/tbRM8WlGX5mPhiA==",
+            "version": "11.1.4",
+            "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-11.1.4.tgz",
+            "integrity": "sha512-Enndh1ApARgYDPfWFgfzLeSgdQVasMj6qDWDArya6quj3Z83AVGsl1YrVe8OxWVWsN7a+56RQRoGNmo9HdldAg==",
             "dev": true,
             "dependencies": {
                 "@types/glob-to-regexp": "^0.4.4",
@@ -6322,11 +6338,12 @@
             }
         },
         "node_modules/finalhandler": {
-            "version": "1.2.0",
-            "license": "MIT",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
             "dependencies": {
                 "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
@@ -6339,14 +6356,16 @@
         },
         "node_modules/finalhandler/node_modules/debug": {
             "version": "2.6.9",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dependencies": {
                 "ms": "2.0.0"
             }
         },
         "node_modules/finalhandler/node_modules/ms": {
             "version": "2.0.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -6424,7 +6443,8 @@
         },
         "node_modules/fresh": {
             "version": "0.5.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -6613,26 +6633,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/gopd": {
             "version": "1.0.1",
             "license": "MIT",
@@ -6808,7 +6808,8 @@
         },
         "node_modules/http-errors": {
             "version": "2.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
             "dependencies": {
                 "depd": "2.0.0",
                 "inherits": "2.0.4",
@@ -6854,9 +6855,9 @@
             }
         },
         "node_modules/husky": {
-            "version": "9.1.5",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.5.tgz",
-            "integrity": "sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==",
+            "version": "9.1.6",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
+            "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
             "dev": true,
             "bin": {
                 "husky": "bin.js"
@@ -9994,8 +9995,12 @@
             }
         },
         "node_modules/merge-descriptors": {
-            "version": "1.0.1",
-            "license": "MIT"
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -10033,7 +10038,8 @@
         },
         "node_modules/mime": {
             "version": "1.6.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "bin": {
                 "mime": "cli.js"
             },
@@ -10209,9 +10215,9 @@
             }
         },
         "node_modules/nodemon": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.4.tgz",
-            "integrity": "sha512-wjPBbFhtpJwmIeY2yP7QF+UKzPfltVGtfce1g/bB15/8vCGZj8uxD62b/b9M9/WVgme0NZudpownKN+c0plXlQ==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.7.tgz",
+            "integrity": "sha512-hLj7fuMow6f0lbB0cD14Lz2xNjwsyruH251Pk4t/yIitCFJbmY1myuLlHm/q06aST4jg6EgAh74PIBBrRqpVAQ==",
             "dev": true,
             "dependencies": {
                 "chokidar": "^3.5.2",
@@ -10515,7 +10521,8 @@
         },
         "node_modules/on-finished": {
             "version": "2.4.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
             "dependencies": {
                 "ee-first": "1.1.1"
             },
@@ -10646,7 +10653,8 @@
         },
         "node_modules/parseurl": {
             "version": "1.3.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -10680,19 +10688,15 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
+        "node_modules/path-to-regexp": {
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+            "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
         },
         "node_modules/picocolors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+            "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -10807,9 +10811,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.41",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
-            "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
+            "version": "8.4.47",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+            "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -10826,8 +10830,8 @@
             ],
             "dependencies": {
                 "nanoid": "^3.3.7",
-                "picocolors": "^1.0.1",
-                "source-map-js": "^1.2.0"
+                "picocolors": "^1.1.0",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -10843,9 +10847,9 @@
             }
         },
         "node_modules/preact-render-to-string": {
-            "version": "6.5.9",
-            "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.9.tgz",
-            "integrity": "sha512-Fn9R89h6qrQeSRmsH2O2fWzqpVwsJgEL9UTly5nGEV2ldhVuG+9JhXdNJ6zreIkOZcBT20+AOMwlG1x72znJ+g==",
+            "version": "6.5.11",
+            "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+            "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
             "peerDependencies": {
                 "preact": ">=10"
             }
@@ -10947,11 +10951,11 @@
             ]
         },
         "node_modules/qs": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
             "dependencies": {
-                "side-channel": "^1.0.4"
+                "side-channel": "^1.0.6"
             },
             "engines": {
                 "node": ">=0.6"
@@ -10985,7 +10989,8 @@
         },
         "node_modules/range-parser": {
             "version": "1.2.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -11420,8 +11425,9 @@
             }
         },
         "node_modules/send": {
-            "version": "0.18.0",
-            "license": "MIT",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
             "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -11443,27 +11449,39 @@
         },
         "node_modules/send/node_modules/debug": {
             "version": "2.6.9",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dependencies": {
                 "ms": "2.0.0"
             }
         },
         "node_modules/send/node_modules/debug/node_modules/ms": {
             "version": "2.0.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "node_modules/send/node_modules/encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/send/node_modules/ms": {
             "version": "2.1.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/serve-static": {
-            "version": "1.15.0",
-            "license": "MIT",
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
             "dependencies": {
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.3",
-                "send": "0.18.0"
+                "send": "0.19.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -11502,7 +11520,8 @@
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -11627,9 +11646,9 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11644,12 +11663,6 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
-        },
-        "node_modules/spawn-command": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
-            "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
-            "dev": true
         },
         "node_modules/spdx-correct": {
             "version": "3.1.1",
@@ -11717,7 +11730,8 @@
         },
         "node_modules/statuses": {
             "version": "2.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -12022,7 +12036,8 @@
         },
         "node_modules/toidentifier": {
             "version": "1.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
             "engines": {
                 "node": ">=0.6"
             }
@@ -12251,9 +12266,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+            "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -12283,9 +12298,9 @@
             "license": "MIT"
         },
         "node_modules/undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
             "devOptional": true
         },
         "node_modules/universal-user-agent": {
@@ -12303,7 +12318,8 @@
         },
         "node_modules/unpipe": {
             "version": "1.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -12393,12 +12409,12 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.4.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.2.tgz",
-            "integrity": "sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==",
+            "version": "5.4.7",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.7.tgz",
+            "integrity": "sha512-5l2zxqMEPVENgvzTuBpHer2awaetimj2BGkhBPdnwKbPNOlHsODU+oiazEZzLK7KhAnOrO+XGYJYn4ZlUhDtDQ==",
             "dependencies": {
                 "esbuild": "^0.21.3",
-                "postcss": "^8.4.41",
+                "postcss": "^8.4.43",
                 "rollup": "^4.20.0"
             },
             "bin": {
@@ -12784,27 +12800,27 @@
             "dependencies": {
                 "compression": "1.7.4",
                 "dotenv": "16.4.5",
-                "express": "4.19.2",
+                "express": "4.21.0",
                 "lodash.debounce": "4.0.8",
-                "lru-cache": "11.0.0",
+                "lru-cache": "11.0.1",
                 "node-fetch": "3.3.2",
                 "node-schedule": "2.1.1",
-                "vite": "5.4.2"
+                "vite": "5.4.7"
             },
             "devDependencies": {
                 "@types/compression": "1.7.5",
                 "@types/express": "4.17.21",
                 "@types/lru-cache": "7.10.10",
-                "@types/node": "20.14.12",
+                "@types/node": "22.6.1",
                 "@types/node-schedule": "2.1.7",
-                "concurrently": "8.2.2",
-                "nodemon": "3.1.4"
+                "concurrently": "9.0.1",
+                "nodemon": "3.1.7"
             }
         },
         "server/node_modules/lru-cache": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
-            "integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
+            "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
             "engines": {
                 "node": "20 || >=22"
             }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "@navikt/ds-css": "7.0.1",
         "@navikt/ds-icons": "3.4.3",
         "@navikt/ds-react": "7.0.1",
-        "@navikt/nav-dekoratoren-moduler": "2.1.6",
+        "@navikt/nav-dekoratoren-moduler": "3.1.0",
         "@preact/compat": "18.3.1",
         "lodash.debounce": "4.0.8",
         "preact-render-to-string": "6.5.11"

--- a/package.json
+++ b/package.json
@@ -19,32 +19,32 @@
         "server"
     ],
     "dependencies": {
-        "@navikt/ds-css": "6.16.2",
+        "@navikt/ds-css": "7.0.1",
         "@navikt/ds-icons": "3.4.3",
-        "@navikt/ds-react": "6.16.2",
+        "@navikt/ds-react": "7.0.1",
         "@navikt/nav-dekoratoren-moduler": "2.1.6",
-        "@preact/compat": "17.1.2",
+        "@preact/compat": "18.3.1",
         "lodash.debounce": "4.0.8",
-        "preact-render-to-string": "6.5.9"
+        "preact-render-to-string": "6.5.11"
     },
     "devDependencies": {
         "@babel/preset-react": "7.24.7",
         "@octokit/core": "6.1.2",
         "@originjs/vite-plugin-commonjs": "1.0.3",
-        "@preact/preset-vite": "2.9.0",
+        "@preact/preset-vite": "2.9.1",
         "@testing-library/jest-dom": "6.5.0",
-        "@testing-library/react": "16.0.0",
-        "@types/jest": "29.5.12",
+        "@testing-library/react": "16.0.1",
+        "@types/jest": "29.5.13",
         "@types/lodash.debounce": "4.0.9",
-        "@types/react": "18.3.4",
+        "@types/react": "18.3.8",
         "@types/react-dom": "18.3.0",
         "@types/react-test-renderer": "18.3.0",
-        "@typescript-eslint/eslint-plugin": "8.2.0",
-        "@typescript-eslint/parser": "8.2.0",
-        "eslint": "9.9.1",
-        "eslint-plugin-react": "7.35.0",
-        "fetch-mock": "11.1.1",
-        "husky": "9.1.5",
+        "@typescript-eslint/eslint-plugin": "8.7.0",
+        "@typescript-eslint/parser": "8.7.0",
+        "eslint": "9.11.1",
+        "eslint-plugin-react": "7.36.1",
+        "fetch-mock": "11.1.4",
+        "husky": "9.1.6",
         "identity-obj-proxy": "3.0.0",
         "jest": "29.7.0",
         "jest-environment-jsdom": "29.7.0",
@@ -54,8 +54,8 @@
         "prettier": "3.3.3",
         "react-test-renderer": "18.3.1",
         "ts-jest": "29.2.5",
-        "typescript": "5.5.4",
-        "vite": "5.4.2"
+        "typescript": "5.6.2",
+        "vite": "5.4.7"
     },
     "browserslist": {
         "production": [

--- a/server/package.json
+++ b/server/package.json
@@ -13,10 +13,11 @@
         "compression": "1.7.4",
         "dotenv": "16.4.5",
         "express": "4.21.0",
+        "lodash.debounce": "4.0.8",
         "lru-cache": "11.0.1",
+        "node-cache": "^5.1.2",
         "node-fetch": "3.3.2",
         "node-schedule": "2.1.1",
-        "lodash.debounce": "4.0.8",
         "vite": "5.4.7"
     },
     "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -12,20 +12,20 @@
     "dependencies": {
         "compression": "1.7.4",
         "dotenv": "16.4.5",
-        "express": "4.19.2",
-        "lru-cache": "11.0.0",
+        "express": "4.21.0",
+        "lru-cache": "11.0.1",
         "node-fetch": "3.3.2",
         "node-schedule": "2.1.1",
         "lodash.debounce": "4.0.8",
-        "vite": "5.4.2"
+        "vite": "5.4.7"
     },
     "devDependencies": {
         "@types/compression": "1.7.5",
         "@types/express": "4.17.21",
         "@types/lru-cache": "7.10.10",
-        "@types/node": "20.14.12",
+        "@types/node": "22.6.1",
         "@types/node-schedule": "2.1.7",
-        "concurrently": "8.2.2",
-        "nodemon": "3.1.4"
+        "concurrently": "9.0.1",
+        "nodemon": "3.1.7"
     }
 }


### PR DESCRIPTION
Oppdatert avhengigheter.

Major oppdateringer: 

@navikt/ds-css: 6.16.2 --> 7.0.1,
@navikt/ds-react: 6.16.2 --> 7.0.1
@preact/compat: 17.1.2 --> 18.3.1
@types/node: 20.14.12 --> 22.6.1
concurrently: 8.2.2 --> 9.0.1

Oppdatering fra @navikt/nav-dekoratoren-moduler: 2.1.6 --> 3.1.0 brekker. Holdes derfor på 2.1.6

Har testet selv lokalt og i dev


