### PR TITLE
Bump dependencies 151024

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,16 +11,16 @@
                 "server"
             ],
             "dependencies": {
-                "@navikt/ds-css": "7.0.1",
+                "@navikt/ds-css": "7.2.1",
                 "@navikt/ds-icons": "3.4.3",
-                "@navikt/ds-react": "7.0.1",
+                "@navikt/ds-react": "7.2.1",
                 "@navikt/nav-dekoratoren-moduler": "3.1.0",
                 "@preact/compat": "18.3.1",
                 "lodash.debounce": "4.0.8",
                 "preact-render-to-string": "6.5.11"
             },
             "devDependencies": {
-                "@babel/preset-react": "7.24.7",
+                "@babel/preset-react": "7.25.7",
                 "@octokit/core": "6.1.2",
                 "@originjs/vite-plugin-commonjs": "1.0.3",
                 "@preact/preset-vite": "2.9.1",
@@ -28,14 +28,14 @@
                 "@testing-library/react": "16.0.1",
                 "@types/jest": "29.5.13",
                 "@types/lodash.debounce": "4.0.9",
-                "@types/react": "18.3.8",
-                "@types/react-dom": "18.3.0",
+                "@types/react": "18.3.11",
+                "@types/react-dom": "18.3.1",
                 "@types/react-test-renderer": "18.3.0",
-                "@typescript-eslint/eslint-plugin": "8.7.0",
-                "@typescript-eslint/parser": "8.7.0",
+                "@typescript-eslint/eslint-plugin": "8.9.0",
+                "@typescript-eslint/parser": "8.9.0",
                 "eslint": "8.57.1",
-                "eslint-plugin-react": "7.36.1",
-                "fetch-mock": "11.1.4",
+                "eslint-plugin-react": "7.37.1",
+                "fetch-mock": "11.1.5",
                 "husky": "9.1.6",
                 "identity-obj-proxy": "3.0.0",
                 "jest": "29.7.0",
@@ -46,8 +46,8 @@
                 "prettier": "3.3.3",
                 "react-test-renderer": "18.3.1",
                 "ts-jest": "29.2.5",
-                "typescript": "5.6.2",
-                "vite": "5.4.7"
+                "typescript": "5.6.3",
+                "vite": "5.4.9"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -78,12 +78,12 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
+            "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.24.7",
+                "@babel/highlight": "^7.25.7",
                 "picocolors": "^1.0.0"
             },
             "engines": {
@@ -130,15 +130,15 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
-            "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
+            "integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.7",
+                "@babel/types": "^7.25.7",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
-                "jsesc": "^2.5.1"
+                "jsesc": "^3.0.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -159,12 +159,12 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
-            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.7.tgz",
+            "integrity": "sha512-4xwU8StnqnlIhhioZf1tqnVWeQ9pvH/ujS8hRfw/WOza+/a+1qv69BWNy+oY231maTCWgKWhfBU7kDpsds6zAA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.7"
+                "@babel/types": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -198,39 +198,14 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-function-name": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
-            "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/template": "^7.24.7",
-                "@babel/types": "^7.24.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
-            "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "^7.24.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
-            "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
+            "integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
             "dev": true,
             "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/traverse": "^7.25.7",
+                "@babel/types": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -256,9 +231,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
-            "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.7.tgz",
+            "integrity": "sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -289,27 +264,27 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-            "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
+            "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
+            "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
-            "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.7.tgz",
+            "integrity": "sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -330,12 +305,12 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
+            "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.25.7",
                 "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
@@ -345,10 +320,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-            "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+            "version": "7.25.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
+            "integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
             "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.25.8"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -417,12 +395,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
-            "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.7.tgz",
+            "integrity": "sha512-ruZOnKO+ajVL/MVx+PwNBPOkrnXTXoWMtte1MBpegfCArhqOe3Bj52avVj1huLLxNKYKXYaSxZ2F+woK1ekXfw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -534,12 +512,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-display-name": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.7.tgz",
-            "integrity": "sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.25.7.tgz",
+            "integrity": "sha512-r0QY7NVU8OnrwE+w2IWiRom0wwsTbjx4+xH2RTd7AVdof3uurXOF+/mXHQDRk+2jIvWgSaCHKMgggfvM4dyUGA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -549,16 +527,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.7.tgz",
-            "integrity": "sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.7.tgz",
+            "integrity": "sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-module-imports": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/plugin-syntax-jsx": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/helper-annotate-as-pure": "^7.25.7",
+                "@babel/helper-module-imports": "^7.25.7",
+                "@babel/helper-plugin-utils": "^7.25.7",
+                "@babel/plugin-syntax-jsx": "^7.25.7",
+                "@babel/types": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -568,12 +546,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx-development": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.24.7.tgz",
-            "integrity": "sha512-QG9EnzoGn+Qar7rxuW+ZOsbWOt56FvvI93xInqsZDC5fsekx1AlIO4KIJ5M+D0p0SqSH156EpmZyXq630B8OlQ==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.25.7.tgz",
+            "integrity": "sha512-5yd3lH1PWxzW6IZj+p+Y4OLQzz0/LzlOG8vGqonHfVR3euf1vyzyMUJk9Ac+m97BH46mFc/98t9PmYLyvgL3qg==",
             "dev": true,
             "dependencies": {
-                "@babel/plugin-transform-react-jsx": "^7.24.7"
+                "@babel/plugin-transform-react-jsx": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -583,13 +561,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-pure-annotations": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.24.7.tgz",
-            "integrity": "sha512-PLgBVk3fzbmEjBJ/u8kFzOqS9tUeDjiaWud/rRym/yjCo/M9cASPlnrd2ZmmZpQT40fOOrvR8jh+n8jikrOhNA==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.25.7.tgz",
+            "integrity": "sha512-6YTHJ7yjjgYqGc8S+CbEXhLICODk0Tn92j+vNJo07HFk9t3bjFgAKxPLFhHwF2NjmQVSI1zBRfBWUeVBa2osfA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-annotate-as-pure": "^7.25.7",
+                "@babel/helper-plugin-utils": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -599,17 +577,17 @@
             }
         },
         "node_modules/@babel/preset-react": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.24.7.tgz",
-            "integrity": "sha512-AAH4lEkpmzFWrGVlHaxJB7RLH21uPQ9+He+eFLWHmF9IuFQVugz8eAsamaW0DXRrTfco5zj1wWtpdcXJUOfsag==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.25.7.tgz",
+            "integrity": "sha512-GjV0/mUEEXpi1U5ZgDprMRRgajGMRW3G5FjMr5KLKD8nT2fTG8+h/klV3+6Dm5739QE+K5+2e91qFKAYI3pmRg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/helper-validator-option": "^7.24.7",
-                "@babel/plugin-transform-react-display-name": "^7.24.7",
-                "@babel/plugin-transform-react-jsx": "^7.24.7",
-                "@babel/plugin-transform-react-jsx-development": "^7.24.7",
-                "@babel/plugin-transform-react-pure-annotations": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.25.7",
+                "@babel/helper-validator-option": "^7.25.7",
+                "@babel/plugin-transform-react-display-name": "^7.25.7",
+                "@babel/plugin-transform-react-jsx": "^7.25.7",
+                "@babel/plugin-transform-react-jsx-development": "^7.25.7",
+                "@babel/plugin-transform-react-pure-annotations": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -630,33 +608,30 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
-            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
+            "integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.24.7",
-                "@babel/parser": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/code-frame": "^7.25.7",
+                "@babel/parser": "^7.25.7",
+                "@babel/types": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
-            "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
+            "integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.24.7",
-                "@babel/helper-environment-visitor": "^7.24.7",
-                "@babel/helper-function-name": "^7.24.7",
-                "@babel/helper-hoist-variables": "^7.24.7",
-                "@babel/helper-split-export-declaration": "^7.24.7",
-                "@babel/parser": "^7.24.7",
-                "@babel/types": "^7.24.7",
+                "@babel/code-frame": "^7.25.7",
+                "@babel/generator": "^7.25.7",
+                "@babel/parser": "^7.25.7",
+                "@babel/template": "^7.25.7",
+                "@babel/types": "^7.25.7",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -665,13 +640,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
-            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+            "version": "7.25.8",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
+            "integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.7",
-                "@babel/helper-validator-identifier": "^7.24.7",
+                "@babel/helper-string-parser": "^7.25.7",
+                "@babel/helper-validator-identifier": "^7.25.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -2086,14 +2061,14 @@
             }
         },
         "node_modules/@navikt/aksel-icons": {
-            "version": "7.0.1",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/7.0.1/e577737bb8025322cbe3a147cd33ad0e1ce35732",
-            "integrity": "sha512-5atdxy8VCgGTG5t1j5niaR/xLH9Z/sghvVQdeUjEOqF/6FQYbYsQdwGWa3UCkExWQk6n1yHuj2mFbM756adZfg=="
+            "version": "7.2.1",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/7.2.1/8cc80c4d03f7d22428f72fd4cb6a93946b087db1",
+            "integrity": "sha512-AQNR2ld5Kjx1A8LA7TnRxztbNf27UFMFt9vitSIlHGVHvWppSzIrxRhBESsldUDRxMQUjJrFY72o53whF0lhxQ=="
         },
         "node_modules/@navikt/ds-css": {
-            "version": "7.0.1",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/7.0.1/aa975b0014976ba552205e4fbd5ff68b886d6b93",
-            "integrity": "sha512-IAgJ2AessJbul3JE3DWq2AIfn7MgaF+sZg6W6+ren/S/X5o88KwrqWMqYCxcSf0xaRd9ceVLmJ6W5QOt9fJ4wQ=="
+            "version": "7.2.1",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/7.2.1/4201a8c184239da9b0c546a94a25ee985c89fc3c",
+            "integrity": "sha512-0SRFwm2Iyuz4noxL98h5LObklJ9oaxiLsCSECOY2LohMy+XcfOoQQ/6eeGhTURqmLSnJYsdTFs2peV0ZX+Ukig=="
         },
         "node_modules/@navikt/ds-icons": {
             "version": "3.4.3",
@@ -2106,14 +2081,14 @@
             }
         },
         "node_modules/@navikt/ds-react": {
-            "version": "7.0.1",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/7.0.1/fe247ebc8a957b2b677e25a019ba9a9831f4e704",
-            "integrity": "sha512-6pAccYY5Tww59Vd3sraHNAqGdB03ugcDc1g8UIfohyxVkKaXImJ5mLLwzD/O5NewO0xdD0Lne692fN/rGz+xog==",
+            "version": "7.2.1",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/7.2.1/d8283fca0fea8efb9281f54dc08e424d4f4e0078",
+            "integrity": "sha512-zVewWWjBCiHd1TchuzBlQVYBYjBJ0v5vbnvXvDaP0I4zbG4b+Fb71F+Oxn7HyaboXEkXk0TlZjerylEdtc28zg==",
             "dependencies": {
                 "@floating-ui/react": "0.25.4",
                 "@floating-ui/react-dom": "^2.0.9",
-                "@navikt/aksel-icons": "^7.0.1",
-                "@navikt/ds-tokens": "^7.0.1",
+                "@navikt/aksel-icons": "^7.2.1",
+                "@navikt/ds-tokens": "^7.2.1",
                 "clsx": "^2.1.0",
                 "date-fns": "^3.0.0",
                 "react-day-picker": "8.10.0"
@@ -2133,9 +2108,9 @@
             }
         },
         "node_modules/@navikt/ds-tokens": {
-            "version": "7.0.1",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/7.0.1/476acfd2558df6284de7915317e227afbe3176c0",
-            "integrity": "sha512-aMi9G/vIwqAQRX2fwnFehmzNnEfMjuTkzc55nVR50fw0QKa0NXgjuAnIYZGLdNmE4y+fvxCx1uOY+cUBccqFQQ=="
+            "version": "7.2.1",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/7.2.1/0df577b32219208add6ca8646449fb558faad282",
+            "integrity": "sha512-u2Aog1I10uWKJra4aFwXiMvgo/f23E7No9l0RhzCRIatQ9qFjaaV1koEtftGBS0VbkVmRgjSeSkGb4SzgiUSbw=="
         },
         "node_modules/@navikt/nav-dekoratoren-moduler": {
             "version": "3.1.0",
@@ -3006,21 +2981,21 @@
             "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
         },
         "node_modules/@types/express": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
+            "integrity": "sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==",
             "dev": true,
             "dependencies": {
                 "@types/body-parser": "*",
-                "@types/express-serve-static-core": "^4.17.33",
+                "@types/express-serve-static-core": "^5.0.0",
                 "@types/qs": "*",
                 "@types/serve-static": "*"
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.17.37",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz",
-            "integrity": "sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.0.tgz",
+            "integrity": "sha512-AbXMTZGt40T+KON9/Fdxx0B2WK5hsgxcfXJLr5bFpZ7b4JCex2WyQPTEKdXqfHiY5nKKBScZ7yCoO6Pvgxfvnw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -3158,9 +3133,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "22.6.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.6.1.tgz",
-            "integrity": "sha512-V48tCfcKb/e6cVUigLAaJDAILdMP0fUW6BidkPK4GpGjXcfbnoHasCZDwz3N3yVt5we2RHm4XTQCpv0KJz9zqw==",
+            "version": "22.7.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+            "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
             "devOptional": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
@@ -3180,30 +3155,30 @@
             "license": "MIT"
         },
         "node_modules/@types/qs": {
-            "version": "6.9.8",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
-            "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==",
+            "version": "6.9.16",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
+            "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
             "dev": true
         },
         "node_modules/@types/range-parser": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
-            "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
             "dev": true
         },
         "node_modules/@types/react": {
-            "version": "18.3.8",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.8.tgz",
-            "integrity": "sha512-syBUrW3/XpnW4WJ41Pft+I+aPoDVbrBVQGEnbD7NijDGlVC+8gV/XKRY+7vMDlfPpbwYt0l1vd/Sj8bJGMbs9Q==",
+            "version": "18.3.11",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+            "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "18.3.0",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-            "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
+            "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
             "dev": true,
             "dependencies": {
                 "@types/react": "*"
@@ -3219,9 +3194,9 @@
             }
         },
         "node_modules/@types/send": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.2.tgz",
-            "integrity": "sha512-aAG6yRf6r0wQ29bkS+x97BIs64ZLxeE/ARwyS6wrldMm3C1MdKwCcnnEwMC1slI8wuxJOpiUH9MioC0A0i+GJw==",
+            "version": "0.17.4",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+            "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
             "dev": true,
             "dependencies": {
                 "@types/mime": "^1",
@@ -3267,16 +3242,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
-            "integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.9.0.tgz",
+            "integrity": "sha512-Y1n621OCy4m7/vTXNlCbMVp87zSd7NH0L9cXD8aIpOaNlzeWxIK4+Q19A68gSmTNRZn92UjocVUWDthGxtqHFg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.7.0",
-                "@typescript-eslint/type-utils": "8.7.0",
-                "@typescript-eslint/utils": "8.7.0",
-                "@typescript-eslint/visitor-keys": "8.7.0",
+                "@typescript-eslint/scope-manager": "8.9.0",
+                "@typescript-eslint/type-utils": "8.9.0",
+                "@typescript-eslint/utils": "8.9.0",
+                "@typescript-eslint/visitor-keys": "8.9.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -3300,15 +3275,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
-            "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.9.0.tgz",
+            "integrity": "sha512-U+BLn2rqTTHnc4FL3FJjxaXptTxmf9sNftJK62XLz4+GxG3hLHm/SUNaaXP5Y4uTiuYoL5YLy4JBCJe3+t8awQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.7.0",
-                "@typescript-eslint/types": "8.7.0",
-                "@typescript-eslint/typescript-estree": "8.7.0",
-                "@typescript-eslint/visitor-keys": "8.7.0",
+                "@typescript-eslint/scope-manager": "8.9.0",
+                "@typescript-eslint/types": "8.9.0",
+                "@typescript-eslint/typescript-estree": "8.9.0",
+                "@typescript-eslint/visitor-keys": "8.9.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -3328,13 +3303,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
-            "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.9.0.tgz",
+            "integrity": "sha512-bZu9bUud9ym1cabmOYH9S6TnbWRzpklVmwqICeOulTCZ9ue2/pczWzQvt/cGj2r2o1RdKoZbuEMalJJSYw3pHQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.7.0",
-                "@typescript-eslint/visitor-keys": "8.7.0"
+                "@typescript-eslint/types": "8.9.0",
+                "@typescript-eslint/visitor-keys": "8.9.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3345,13 +3320,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
-            "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.9.0.tgz",
+            "integrity": "sha512-JD+/pCqlKqAk5961vxCluK+clkppHY07IbV3vett97KOV+8C6l+CPEPwpUuiMwgbOz/qrN3Ke4zzjqbT+ls+1Q==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.7.0",
-                "@typescript-eslint/utils": "8.7.0",
+                "@typescript-eslint/typescript-estree": "8.9.0",
+                "@typescript-eslint/utils": "8.9.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -3369,9 +3344,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
-            "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.9.0.tgz",
+            "integrity": "sha512-SjgkvdYyt1FAPhU9c6FiYCXrldwYYlIQLkuc+LfAhCna6ggp96ACncdtlbn8FmnG72tUkXclrDExOpEYf1nfJQ==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3382,13 +3357,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
-            "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.9.0.tgz",
+            "integrity": "sha512-9iJYTgKLDG6+iqegehc5+EqE6sqaee7kb8vWpmHZ86EqwDjmlqNNHeqDVqb9duh+BY6WCNHfIGvuVU3Tf9Db0g==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.7.0",
-                "@typescript-eslint/visitor-keys": "8.7.0",
+                "@typescript-eslint/types": "8.9.0",
+                "@typescript-eslint/visitor-keys": "8.9.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -3446,15 +3421,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
-            "integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.9.0.tgz",
+            "integrity": "sha512-PKgMmaSo/Yg/F7kIZvrgrWa1+Vwn036CdNUvYFEkYbPwOH4i8xvkaRlu148W3vtheWK9ckKRIz7PBP5oUlkrvQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.7.0",
-                "@typescript-eslint/types": "8.7.0",
-                "@typescript-eslint/typescript-estree": "8.7.0"
+                "@typescript-eslint/scope-manager": "8.9.0",
+                "@typescript-eslint/types": "8.9.0",
+                "@typescript-eslint/typescript-estree": "8.9.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3468,12 +3443,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
-            "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.9.0.tgz",
+            "integrity": "sha512-Ht4y38ubk4L5/U8xKUBfKNYGmvKvA1CANoxiTRMM+tOLk3lbF3DvzZCxJCRSE+2GdCMSh6zq9VZJc3asc1XuAA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.7.0",
+                "@typescript-eslint/types": "8.9.0",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -4516,9 +4491,9 @@
             "dev": true
         },
         "node_modules/cookie": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5812,9 +5787,9 @@
             }
         },
         "node_modules/eslint-plugin-react": {
-            "version": "7.36.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.36.1.tgz",
-            "integrity": "sha512-/qwbqNXZoq+VP30s1d4Nc1C5GTxjJQjk4Jzs4Wq2qzxFM7dSmuG2UkIjg2USMLh3A/aVcUNrK7v0J5U1XEGGwA==",
+            "version": "7.37.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
+            "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
             "dev": true,
             "dependencies": {
                 "array-includes": "^3.1.8",
@@ -6132,16 +6107,16 @@
             }
         },
         "node_modules/express": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-            "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+            "version": "4.21.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+            "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.20.3",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.6.0",
+                "cookie": "0.7.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -6268,9 +6243,9 @@
             }
         },
         "node_modules/fetch-mock": {
-            "version": "11.1.4",
-            "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-11.1.4.tgz",
-            "integrity": "sha512-Enndh1ApARgYDPfWFgfzLeSgdQVasMj6qDWDArya6quj3Z83AVGsl1YrVe8OxWVWsN7a+56RQRoGNmo9HdldAg==",
+            "version": "11.1.5",
+            "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-11.1.5.tgz",
+            "integrity": "sha512-KHmZDnZ1ry0pCTrX4YG5DtThHi0MH+GNI9caESnzX/nMJBrvppUHMvLx47M0WY9oAtKOMiPfZDRpxhlHg89BOA==",
             "dev": true,
             "dependencies": {
                 "@types/glob-to-regexp": "^0.4.4",
@@ -9854,14 +9829,15 @@
             }
         },
         "node_modules/jsesc": {
-            "version": "2.5.2",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=6"
             }
         },
         "node_modules/json-buffer": {
@@ -12491,9 +12467,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-            "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+            "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -12637,9 +12613,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.4.7",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.7.tgz",
-            "integrity": "sha512-5l2zxqMEPVENgvzTuBpHer2awaetimj2BGkhBPdnwKbPNOlHsODU+oiazEZzLK7KhAnOrO+XGYJYn4ZlUhDtDQ==",
+            "version": "5.4.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.9.tgz",
+            "integrity": "sha512-20OVpJHh0PAM0oSOELa5GaZNWeDjcAvQjGXy2Uyr+Tp+/D2/Hdz6NLgpJLsarPTA2QJ6v8mX2P1ZfbsSKvdMkg==",
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -13035,22 +13011,46 @@
             "dependencies": {
                 "compression": "1.7.4",
                 "dotenv": "16.4.5",
-                "express": "4.21.0",
+                "express": "4.21.1",
                 "lodash.debounce": "4.0.8",
                 "lru-cache": "11.0.1",
                 "node-cache": "^5.1.2",
                 "node-fetch": "3.3.2",
                 "node-schedule": "2.1.1",
-                "vite": "5.4.7"
+                "vite": "5.4.9"
             },
             "devDependencies": {
                 "@types/compression": "1.7.5",
                 "@types/express": "4.17.21",
                 "@types/lru-cache": "7.10.10",
-                "@types/node": "22.6.1",
+                "@types/node": "22.7.5",
                 "@types/node-schedule": "2.1.7",
                 "concurrently": "9.0.1",
                 "nodemon": "3.1.7"
+            }
+        },
+        "server/node_modules/@types/express": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^4.17.33",
+                "@types/qs": "*",
+                "@types/serve-static": "*"
+            }
+        },
+        "server/node_modules/@types/express-serve-static-core": {
+            "version": "4.19.6",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+            "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
             }
         },
         "server/node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
         "server"
     ],
     "dependencies": {
-        "@navikt/ds-css": "7.0.1",
+        "@navikt/ds-css": "7.2.1",
         "@navikt/ds-icons": "3.4.3",
-        "@navikt/ds-react": "7.0.1",
+        "@navikt/ds-react": "7.2.1",
         "@navikt/nav-dekoratoren-moduler": "3.1.0",
         "@preact/compat": "18.3.1",
         "lodash.debounce": "4.0.8",
         "preact-render-to-string": "6.5.11"
     },
     "devDependencies": {
-        "@babel/preset-react": "7.24.7",
+        "@babel/preset-react": "7.25.7",
         "@octokit/core": "6.1.2",
         "@originjs/vite-plugin-commonjs": "1.0.3",
         "@preact/preset-vite": "2.9.1",
@@ -36,14 +36,14 @@
         "@testing-library/react": "16.0.1",
         "@types/jest": "29.5.13",
         "@types/lodash.debounce": "4.0.9",
-        "@types/react": "18.3.8",
-        "@types/react-dom": "18.3.0",
+        "@types/react": "18.3.11",
+        "@types/react-dom": "18.3.1",
         "@types/react-test-renderer": "18.3.0",
-        "@typescript-eslint/eslint-plugin": "8.7.0",
-        "@typescript-eslint/parser": "8.7.0",
+        "@typescript-eslint/eslint-plugin": "8.9.0",
+        "@typescript-eslint/parser": "8.9.0",
         "eslint": "8.57.1",
-        "eslint-plugin-react": "7.36.1",
-        "fetch-mock": "11.1.4",
+        "eslint-plugin-react": "7.37.1",
+        "fetch-mock": "11.1.5",
         "husky": "9.1.6",
         "identity-obj-proxy": "3.0.0",
         "jest": "29.7.0",
@@ -54,8 +54,8 @@
         "prettier": "3.3.3",
         "react-test-renderer": "18.3.1",
         "ts-jest": "29.2.5",
-        "typescript": "5.6.2",
-        "vite": "5.4.7"
+        "typescript": "5.6.3",
+        "vite": "5.4.9"
     },
     "browserslist": {
         "production": [

--- a/server/package.json
+++ b/server/package.json
@@ -12,19 +12,19 @@
     "dependencies": {
         "compression": "1.7.4",
         "dotenv": "16.4.5",
-        "express": "4.21.0",
+        "express": "4.21.1",
         "lodash.debounce": "4.0.8",
         "lru-cache": "11.0.1",
         "node-cache": "^5.1.2",
         "node-fetch": "3.3.2",
         "node-schedule": "2.1.1",
-        "vite": "5.4.7"
+        "vite": "5.4.9"
     },
     "devDependencies": {
         "@types/compression": "1.7.5",
         "@types/express": "4.17.21",
         "@types/lru-cache": "7.10.10",
-        "@types/node": "22.6.1",
+        "@types/node": "22.7.5",
         "@types/node-schedule": "2.1.7",
         "concurrently": "9.0.1",
         "nodemon": "3.1.7"


### PR DESCRIPTION
## Hva er gjort

Oppdatert avhengigheter.

Ingen større oppdateringer.

Holder fortsatt eslint på 8.57.1 i stedet for 9.12.0.

Må også holde types/express på versjon 4.17.21  (5.0.0 brekker).

## Testing

Har testet lokalt og i dev.