### PR TITLE
Fjerner sperre for eksterne kall mot API

### DIFF
--- a/server/src/api/registerApiRoutes.ts
+++ b/server/src/api/registerApiRoutes.ts
@@ -12,9 +12,6 @@ export const registerApiRoutes = async (router: Router) => {
     router.get(
         '/search',
         (req, res, next) => {
-            if (!req.headers['nav-office-search-client']) {
-                return res.status(403).send({ error: 'Forbidden' });
-            }
             next();
         },
         searchHandler

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -17,7 +17,6 @@ export const fetchSearchClient = (
 
     return fetch(`${clientUrls.searchApi}?query=${query}`, {
         signal: abortController.signal,
-        headers: { 'Nav-Office-Search-Client': '1' },
     })
         .then((res) => res.json())
         .catch((e): SearchResultErrorProps => {


### PR DESCRIPTION
Var visst andre deler av Nav som hadde hektet seg på vårt API uten å spørre oss. Vi velger å være på tilbudssiden og fjerne denne sperren, ihvertfall i en periode.